### PR TITLE
Restructure voice DTOs with nested chunkPlan/formatPlan

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/AzureVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/AzureVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.AzureVoiceProperties
 
 @Vapi4KDslMarker
-interface AzureVoice : AzureVoiceProperties
+interface AzureVoice : AzureVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/CartesiaVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/CartesiaVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.CartesiaVoiceProperties
 
 @Vapi4KDslMarker
-interface CartesiaVoice : CartesiaVoiceProperties
+interface CartesiaVoice : CartesiaVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/ChunkPlan.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/ChunkPlan.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k.api.voice
+
+import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
+import com.vapi4k.dsl.voice.ChunkPlanProperties
+
+/**
+<p>This is the chunk plan for the voice output. It controls how the model output is split into chunks
+before being sent to the voice provider for generation.
+<br>Default <code>true</code> because voice generation sounds better with chunking (and reformatting them).
+<br>To send every token from the model output directly to the voice provider and rely on the voice provider's audio
+generation logic, set <code>enabled</code> to <code>false</code>.
+</p>
+ */
+@Vapi4KDslMarker
+interface ChunkPlan : ChunkPlanProperties {
+  /**
+  <p>This is the format plan for how chunks are reformatted before being sent to the voice provider. Many things are
+  reformatted including phone numbers, emails and addresses to improve their enunciation.
+  </p>
+   */
+  fun formatPlan(block: FormatPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/DeepgramVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/DeepgramVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.DeepgramVoiceProperties
 
 @Vapi4KDslMarker
-interface DeepgramVoice : DeepgramVoiceProperties
+interface DeepgramVoice : DeepgramVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/ElevenLabsVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/ElevenLabsVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.ElevenLabsVoiceProperties
 
 @Vapi4KDslMarker
-interface ElevenLabsVoice : ElevenLabsVoiceProperties
+interface ElevenLabsVoice : ElevenLabsVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/FormatPlan.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/FormatPlan.kt
@@ -17,14 +17,14 @@
 package com.vapi4k.api.voice
 
 import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
-import com.vapi4k.dsl.voice.LMNTVoiceProperties
+import com.vapi4k.dsl.voice.FormatPlanProperties
 
+/**
+<p>This is the format plan for the voice output. It controls how text is reformatted before being sent to the voice
+provider. Many things are reformatted including phone numbers, emails and addresses to improve their enunciation.
+<br>Default <code>true</code> because voice generation sounds better with reformatting.
+<br>To disable chunk reformatting, set <code>enabled</code> to <code>false</code>.
+</p>
+ */
 @Vapi4KDslMarker
-interface LMNTVoice : LMNTVoiceProperties {
-  /**
-  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
-  voice provider for generation.
-  </p>
-   */
-  fun chunkPlan(block: ChunkPlan.() -> Unit)
-}
+interface FormatPlan : FormatPlanProperties

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/NeetsVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/NeetsVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.NeetsVoiceProperties
 
 @Vapi4KDslMarker
-interface NeetsVoice : NeetsVoiceProperties
+interface NeetsVoice : NeetsVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/OpenAIVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/OpenAIVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.OpenAIVoiceProperties
 
 @Vapi4KDslMarker
-interface OpenAIVoice : OpenAIVoiceProperties
+interface OpenAIVoice : OpenAIVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/PlayHTVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/PlayHTVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.PlayHTVoiceProperties
 
 @Vapi4KDslMarker
-interface PlayHTVoice : PlayHTVoiceProperties
+interface PlayHTVoice : PlayHTVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/RimeAIVoice.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/RimeAIVoice.kt
@@ -20,4 +20,11 @@ import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 import com.vapi4k.dsl.voice.RimeAIVoiceProperties
 
 @Vapi4KDslMarker
-interface RimeAIVoice : RimeAIVoiceProperties
+interface RimeAIVoice : RimeAIVoiceProperties {
+  /**
+  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
+  voice provider for generation.
+  </p>
+   */
+  fun chunkPlan(block: ChunkPlan.() -> Unit)
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/AzureVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/AzureVoiceImpl.kt
@@ -17,9 +17,14 @@
 package com.vapi4k.dsl.voice
 
 import com.vapi4k.api.voice.AzureVoice
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.dtos.voice.AzureVoiceDto
 
 internal class AzureVoiceImpl(
   private val dto: AzureVoiceDto,
 ) : AzureVoiceProperties by dto,
-  AzureVoice
+  AzureVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/CartesiaVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/CartesiaVoiceImpl.kt
@@ -17,9 +17,14 @@
 package com.vapi4k.dsl.voice
 
 import com.vapi4k.api.voice.CartesiaVoice
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.dtos.voice.CartesiaVoiceDto
 
 internal class CartesiaVoiceImpl(
   private val dto: CartesiaVoiceDto,
 ) : CartesiaVoiceProperties by dto,
-  CartesiaVoice
+  CartesiaVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanImpl.kt
@@ -14,17 +14,17 @@
  *
  */
 
-package com.vapi4k.api.voice
+package com.vapi4k.dsl.voice
 
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
-import com.vapi4k.dsl.voice.LMNTVoiceProperties
+import com.vapi4k.api.voice.ChunkPlan
+import com.vapi4k.api.voice.FormatPlan
+import com.vapi4k.dtos.voice.ChunkPlanDto
 
-@Vapi4KDslMarker
-interface LMNTVoice : LMNTVoiceProperties {
-  /**
-  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
-  voice provider for generation.
-  </p>
-   */
-  fun chunkPlan(block: ChunkPlan.() -> Unit)
+class ChunkPlanImpl internal constructor(
+  private val dto: ChunkPlanDto,
+) : ChunkPlanProperties by dto,
+  ChunkPlan {
+  override fun formatPlan(block: FormatPlan.() -> Unit) {
+    FormatPlanImpl(dto.formatPlan).apply(block)
+  }
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanProperties.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanProperties.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k.dsl.voice
+
+import com.vapi4k.api.voice.PunctuationType
+
+interface ChunkPlanProperties {
+  /**
+  <p>This determines whether the model output is preprocessed into chunks before being sent to the voice provider.
+  <br>Default <code>true</code> because voice generation sounds better with chunking (and reformatting them).
+  <br>To send every token from the model output directly to the voice provider and rely on the voice provider's audio
+  generation logic, set this to <code>false</code>.
+  <br>If disabled, vapi-provided audio control tokens like &lt;flush /&gt; will not work.
+  </p>
+   */
+  var enabled: Boolean?
+
+  /**
+  <p>This is the minimum number of characters before a chunk is created. The chunks that are sent to the voice provider
+  for the voice generation as the model tokens are streaming in. Defaults to 30.
+  <br>Increasing this value might add latency as it waits for the model to output a full chunk before sending it to the
+  voice provider. On the other hand, increasing might be a good idea if you want to give voice provider bigger chunks,
+  so it can pronounce them better.
+  <br>Decreasing this value might decrease latency but might also decrease quality if the voice provider struggles to
+  pronounce the text correctly.
+  </p>
+   */
+  var minCharacters: Int
+
+  /**
+  <p>These are the punctuations that are considered valid boundaries before a chunk is created. The chunks that are sent
+  to the voice provider for the voice generation as the model tokens are streaming in. Defaults are chosen differently
+  for each provider.
+  <br>Constraining the delimiters might add latency as it waits for the model to output a full chunk before sending it to
+  the voice provider. On the other hand, constraining might be a good idea if you want to give voice provider longer
+  chunks, so it can sound less disjointed across chunks. Eg. ['.'].
+  </p>
+   */
+  val punctuationBoundaries: MutableSet<PunctuationType>
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/CommonVoiceProperties.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/CommonVoiceProperties.kt
@@ -16,8 +16,6 @@
 
 package com.vapi4k.dsl.voice
 
-import com.vapi4k.api.voice.PunctuationType
-
 interface CommonVoiceProperties {
   /**
   <p>This determines whether fillers are injected into the model output before inputting it into the voice provider.
@@ -25,47 +23,4 @@ interface CommonVoiceProperties {
   </p>
    */
   var fillerInjectionEnabled: Boolean?
-
-  /**
-  <p>This is the minimum number of characters before a chunk is created. The chunks that are sent to the voice provider
-  for the voice generation as the model tokens are streaming in. Defaults to 30.
-  <br>Increasing this value might add latency as it waits for the model to output a full chunk before sending it to the
-  voice provider. On the other hand, increasing might be a good idea if you want to give voice provider bigger chunks,
-  so it can pronounce them better.
-  <br>Decreasing this value might decrease latency but might also decrease quality if the voice provider struggles to
-  pronounce the text correctly.
-  </p>
-   */
-  var inputMinCharacters: Int
-
-  /**
-  <p>This determines whether the model output is preprocessed into chunks before being sent to the voice provider.
-  <br>Default `true` because voice generation sounds better with chunking (and reformatting them).
-  <br>To send every token from the model output directly to the voice provider and rely on the voice provider's audio
-  generation logic, set this to `false`.
-  <br>If disabled, vapi-provided audio control tokens like <flush /> will not work.
-  </p>
-   */
-  var inputPreprocessingEnabled: Boolean?
-
-  /**
-  <p>These are the punctuations that are considered valid boundaries before a chunk is created. The chunks that are sent
-  to the voice provider for the voice generation as the model tokens are streaming in. Defaults are chosen differently
-  for each provider.
-  <br>Constraining the delimiters might add latency as it waits for the model to output a full chunk before sending it to
-  the voice provider. On the other hand, constraining might be a good idea if you want to give voice provider longer
-  chunks, so it can sound less disjointed across chunks. Eg. ['.'].
-  </p>
-   */
-  val inputPunctuationBoundaries: MutableSet<PunctuationType>
-
-  /**
-  <p>This determines whether the chunk is reformatted before being sent to the voice provider. Many things are reformatted
-  including phone numbers, emails and addresses to improve their enunciation.
-  <br>Default `true` because voice generation sounds better with reformatting.
-  <br>To disable chunk reformatting, set this to `false`.
-  <br>To disable chunking completely, set `inputPreprocessingEnabled` to `false`.
-  </p>
-   */
-  var inputReformattingEnabled: Boolean?
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/DeepgramVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/DeepgramVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.DeepgramVoice
 import com.vapi4k.dtos.voice.DeepgramVoiceDto
 
 internal class DeepgramVoiceImpl(
   private val dto: DeepgramVoiceDto,
 ) : DeepgramVoiceProperties by dto,
-  DeepgramVoice
+  DeepgramVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ElevenLabsVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ElevenLabsVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.ElevenLabsVoice
 import com.vapi4k.dtos.voice.ElevenLabsVoiceDto
 
 internal class ElevenLabsVoiceImpl(
   private val dto: ElevenLabsVoiceDto,
 ) : ElevenLabsVoiceProperties by dto,
-  ElevenLabsVoice
+  ElevenLabsVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/FormatPlanImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/FormatPlanImpl.kt
@@ -14,17 +14,12 @@
  *
  */
 
-package com.vapi4k.api.voice
+package com.vapi4k.dsl.voice
 
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
-import com.vapi4k.dsl.voice.LMNTVoiceProperties
+import com.vapi4k.api.voice.FormatPlan
+import com.vapi4k.dtos.voice.FormatPlanDto
 
-@Vapi4KDslMarker
-interface LMNTVoice : LMNTVoiceProperties {
-  /**
-  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
-  voice provider for generation.
-  </p>
-   */
-  fun chunkPlan(block: ChunkPlan.() -> Unit)
-}
+class FormatPlanImpl internal constructor(
+  private val dto: FormatPlanDto,
+) : FormatPlanProperties by dto,
+  FormatPlan

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/FormatPlanProperties.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/FormatPlanProperties.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k.dsl.voice
+
+interface FormatPlanProperties {
+  /**
+  <p>This determines whether the chunk is reformatted before being sent to the voice provider. Many things are reformatted
+  including phone numbers, emails and addresses to improve their enunciation.
+  <br>Default <code>true</code> because voice generation sounds better with reformatting.
+  <br>To disable chunk reformatting, set this to <code>false</code>.
+  </p>
+   */
+  var enabled: Boolean?
+
+  /**
+  <p>This is the cutoff after which a number is converted to individual digits instead of being spoken as a whole number.
+  <br>Example: if set to 2025, the number 2024 will be spoken as "twenty twenty-four" but 2026 will be spoken as
+  "two zero two six".
+  <br>Set to 0 to always convert to digits. Set to a very large number to never convert to digits.
+  <br>Defaults to -1 (unset, uses Vapi default behavior).
+  </p>
+   */
+  var numberToDigitsCutoff: Int
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/LMNTVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/LMNTVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.LMNTVoice
 import com.vapi4k.dtos.voice.LMNTVoiceDto
 
 internal class LMNTVoiceImpl(
   private val dto: LMNTVoiceDto,
 ) : LMNTVoiceProperties by dto,
-  LMNTVoice
+  LMNTVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/NeetsVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/NeetsVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.NeetsVoice
 import com.vapi4k.dtos.voice.NeetsVoiceDto
 
 internal class NeetsVoiceImpl(
   private val dto: NeetsVoiceDto,
 ) : NeetsVoiceProperties by dto,
-  NeetsVoice
+  NeetsVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/OpenAIVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/OpenAIVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.OpenAIVoice
 import com.vapi4k.dtos.voice.OpenAIVoiceDto
 
 internal class OpenAIVoiceImpl(
   private val dto: OpenAIVoiceDto,
 ) : OpenAIVoiceProperties by dto,
-  OpenAIVoice
+  OpenAIVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/PlayHTVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/PlayHTVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.PlayHTVoice
 import com.vapi4k.dtos.voice.PlayHTVoiceDto
 
 internal class PlayHTVoiceImpl(
   private val dto: PlayHTVoiceDto,
 ) : PlayHTVoiceProperties by dto,
-  PlayHTVoice
+  PlayHTVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/RimeAIVoiceImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/RimeAIVoiceImpl.kt
@@ -16,10 +16,15 @@
 
 package com.vapi4k.dsl.voice
 
+import com.vapi4k.api.voice.ChunkPlan
 import com.vapi4k.api.voice.RimeAIVoice
 import com.vapi4k.dtos.voice.RimeAIVoiceDto
 
 internal class RimeAIVoiceImpl(
   private val dto: RimeAIVoiceDto,
 ) : RimeAIVoiceProperties by dto,
-  RimeAIVoice
+  RimeAIVoice {
+  override fun chunkPlan(block: ChunkPlan.() -> Unit) {
+    ChunkPlanImpl(dto.chunkPlan).apply(block)
+  }
+}

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/AbstractVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/AbstractVoiceDto.kt
@@ -16,14 +16,9 @@
 
 package com.vapi4k.dtos.voice
 
-import com.vapi4k.api.voice.PunctuationType
 import kotlinx.serialization.Serializable
 
 @Serializable
 abstract class AbstractVoiceDto {
-  var inputPreprocessingEnabled: Boolean? = null
-  var inputReformattingEnabled: Boolean? = null
-  var inputMinCharacters: Int = -1
-  val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf()
   var fillerInjectionEnabled: Boolean? = null
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/AzureVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/AzureVoiceDto.kt
@@ -17,7 +17,6 @@
 package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.AzureVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.AzureVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -26,11 +25,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class AzureVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: AzureVoiceIdType = AzureVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/CartesiaVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/CartesiaVoiceDto.kt
@@ -18,7 +18,6 @@ package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.CartesiaVoiceLanguageType
 import com.vapi4k.api.voice.CartesiaVoiceModelType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.CartesiaVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -27,11 +26,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class CartesiaVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var model: String = "",
   @Transient
   override var modelType: CartesiaVoiceModelType = CartesiaVoiceModelType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ChunkPlanDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ChunkPlanDto.kt
@@ -14,17 +14,16 @@
  *
  */
 
-package com.vapi4k.api.voice
+package com.vapi4k.dtos.voice
 
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
-import com.vapi4k.dsl.voice.LMNTVoiceProperties
+import com.vapi4k.api.voice.PunctuationType
+import com.vapi4k.dsl.voice.ChunkPlanProperties
+import kotlinx.serialization.Serializable
 
-@Vapi4KDslMarker
-interface LMNTVoice : LMNTVoiceProperties {
-  /**
-  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
-  voice provider for generation.
-  </p>
-   */
-  fun chunkPlan(block: ChunkPlan.() -> Unit)
-}
+@Serializable
+data class ChunkPlanDto(
+  override var enabled: Boolean? = null,
+  override var minCharacters: Int = -1,
+  override val punctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
+  val formatPlan: FormatPlanDto = FormatPlanDto(),
+) : ChunkPlanProperties

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/DeepgramVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/DeepgramVoiceDto.kt
@@ -17,7 +17,6 @@
 package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.DeepGramVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.DeepgramVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -26,11 +25,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class DeepgramVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: DeepGramVoiceIdType = DeepGramVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ElevenLabsVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ElevenLabsVoiceDto.kt
@@ -18,7 +18,6 @@ package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.ElevenLabsVoiceIdType
 import com.vapi4k.api.voice.ElevenLabsVoiceModelType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.ElevenLabsVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -27,11 +26,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class ElevenLabsVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: ElevenLabsVoiceIdType = ElevenLabsVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/FormatPlanDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/FormatPlanDto.kt
@@ -14,17 +14,13 @@
  *
  */
 
-package com.vapi4k.api.voice
+package com.vapi4k.dtos.voice
 
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
-import com.vapi4k.dsl.voice.LMNTVoiceProperties
+import com.vapi4k.dsl.voice.FormatPlanProperties
+import kotlinx.serialization.Serializable
 
-@Vapi4KDslMarker
-interface LMNTVoice : LMNTVoiceProperties {
-  /**
-  <p>This is the chunk plan for controlling how the model output is split into chunks before being sent to the
-  voice provider for generation.
-  </p>
-   */
-  fun chunkPlan(block: ChunkPlan.() -> Unit)
-}
+@Serializable
+data class FormatPlanDto(
+  override var enabled: Boolean? = null,
+  override var numberToDigitsCutoff: Int = -1,
+) : FormatPlanProperties

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/LMNTVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/LMNTVoiceDto.kt
@@ -17,7 +17,6 @@
 package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.LMNTVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.LMNTVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -26,11 +25,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class LMNTVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: LMNTVoiceIdType = LMNTVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/NeetsVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/NeetsVoiceDto.kt
@@ -17,7 +17,6 @@
 package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.NeetsVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.NeetsVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -26,11 +25,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class NeetsVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: NeetsVoiceIdType = NeetsVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/OpenAIVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/OpenAIVoiceDto.kt
@@ -17,7 +17,6 @@
 package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.OpenAIVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.OpenAIVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -26,11 +25,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class OpenAIVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: OpenAIVoiceIdType = OpenAIVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/PlayHTVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/PlayHTVoiceDto.kt
@@ -18,7 +18,6 @@ package com.vapi4k.dtos.voice
 
 import com.vapi4k.api.voice.PlayHTVoiceEmotionType
 import com.vapi4k.api.voice.PlayHTVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.VoiceProviderType
 import com.vapi4k.dsl.voice.PlayHTVoiceProperties
 import kotlinx.serialization.EncodeDefault
@@ -27,11 +26,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class PlayHTVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: PlayHTVoiceIdType = PlayHTVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/RimeAIVoiceDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/RimeAIVoiceDto.kt
@@ -16,7 +16,6 @@
 
 package com.vapi4k.dtos.voice
 
-import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.api.voice.RimeAIVoiceIdType
 import com.vapi4k.api.voice.RimeAIVoiceModelType
 import com.vapi4k.api.voice.VoiceProviderType
@@ -27,11 +26,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class RimeAIVoiceDto(
-  override var inputPreprocessingEnabled: Boolean? = null,
-  override var inputReformattingEnabled: Boolean? = null,
-  override var inputMinCharacters: Int = -1,
-  override val inputPunctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
   override var fillerInjectionEnabled: Boolean? = null,
+  val chunkPlan: ChunkPlanDto = ChunkPlanDto(),
   var voiceId: String = "",
   @Transient
   override var voiceIdType: RimeAIVoiceIdType = RimeAIVoiceIdType.UNSPECIFIED,

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
@@ -16,7 +16,9 @@
 
 package com.vapi4k
 
+import com.github.pambrose.common.json.booleanValue
 import com.github.pambrose.common.json.get
+import com.github.pambrose.common.json.intValue
 import com.github.pambrose.common.json.jsonElementList
 import com.github.pambrose.common.json.stringValue
 import com.github.pambrose.common.json.toJsonElement
@@ -26,9 +28,11 @@ import com.vapi4k.api.voice.CartesiaVoiceLanguageType
 import com.vapi4k.api.voice.CartesiaVoiceModelType
 import com.vapi4k.api.voice.PlayHTVoiceEmotionType
 import com.vapi4k.api.voice.PlayHTVoiceIdType
+import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.utils.assistantResponse
 import kotlinx.serialization.json.jsonArray
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test
 
@@ -275,6 +279,86 @@ class VoiceTest {
     }.also {
       it.message shouldBeEqualTo "cartesiaVoice{} already called"
     }
+  }
+
+  @Test
+  fun `chunkPlan serializes as nested JSON`() {
+    val squad =
+      assistantResponse(newRequestContext()) {
+        squad {
+          members {
+            member {
+              assistant {
+                name = "Receptionist"
+                firstMessage = "Hi there!"
+
+                groqModel {
+                  modelType = GroqModelType.LLAMA3_8B_8192
+                }
+
+                cartesiaVoice {
+                  voiceId = "test-voice"
+                  chunkPlan {
+                    enabled = true
+                    minCharacters = 40
+                    punctuationBoundaries += PunctuationType.PERIOD
+                    punctuationBoundaries += PunctuationType.COMMA
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    val jsonElement = squad.toJsonElement()
+    val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
+    voice.stringValue("provider") shouldBeEqualTo "cartesia"
+    voice.stringValue("voiceId") shouldBeEqualTo "test-voice"
+    voice.booleanValue("chunkPlan.enabled").shouldBeTrue()
+    voice.intValue("chunkPlan.minCharacters") shouldBeEqualTo 40
+    voice["chunkPlan.punctuationBoundaries"].jsonArray.size shouldBeEqualTo 2
+  }
+
+  @Test
+  fun `chunkPlan with nested formatPlan serializes correctly`() {
+    val squad =
+      assistantResponse(newRequestContext()) {
+        squad {
+          members {
+            member {
+              assistant {
+                name = "Receptionist"
+                firstMessage = "Hi there!"
+
+                groqModel {
+                  modelType = GroqModelType.LLAMA3_8B_8192
+                }
+
+                cartesiaVoice {
+                  voiceId = "test-voice"
+                  fillerInjectionEnabled = true
+                  chunkPlan {
+                    enabled = true
+                    minCharacters = 50
+                    formatPlan {
+                      enabled = true
+                      numberToDigitsCutoff = 2025
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    val jsonElement = squad.toJsonElement()
+    val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
+    voice.stringValue("provider") shouldBeEqualTo "cartesia"
+    voice.booleanValue("fillerInjectionEnabled").shouldBeTrue()
+    voice.booleanValue("chunkPlan.enabled").shouldBeTrue()
+    voice.intValue("chunkPlan.minCharacters") shouldBeEqualTo 50
+    voice.booleanValue("chunkPlan.formatPlan.enabled").shouldBeTrue()
+    voice.intValue("chunkPlan.formatPlan.numberToDigitsCutoff") shouldBeEqualTo 2025
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Replaces 4 flat voice fields (`inputPreprocessingEnabled`, `inputReformattingEnabled`, `inputMinCharacters`, `inputPunctuationBoundaries`) with nested `chunkPlan { formatPlan { } }` DSL structure matching the Vapi API wire format
- Introduces full 3-layer architecture (API interface + Properties + Impl + DTO) for both `ChunkPlan` and `FormatPlan` following the existing `AnalysisPlan` → `StructuredDataSchema` pattern
- Adds new `FormatPlan.numberToDigitsCutoff` field from the Vapi API
- Adds `chunkPlan {}` builder with KDocs to all 9 voice API interfaces
- `fillerInjectionEnabled` remains at the voice level (not inside chunkPlan)

## Test plan

- [x] `./gradlew build` — all tests pass
- [x] `./gradlew lintKotlin` — no style violations
- [x] New test: `chunkPlan serializes as nested JSON` — verifies `chunkPlan.enabled`, `chunkPlan.minCharacters`, `chunkPlan.punctuationBoundaries` nest correctly
- [x] New test: `chunkPlan with nested formatPlan serializes correctly` — verifies `chunkPlan.formatPlan.enabled` and `chunkPlan.formatPlan.numberToDigitsCutoff` nest correctly, and `fillerInjectionEnabled` stays at voice level
- [ ] Verify no snippet code references the old flat properties (confirmed: none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)