### PR TITLE
Bump dependency versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ publish:
 	./gradlew publishToMavenLocal
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.2.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=9.4.0 --distribution-type=bin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-config = "6.0.7"
+config = "6.0.9"
 dokka = "2.1.0"
 exposed = "1.1.1"
 gradle-plugins = "1.0.8"
@@ -11,11 +11,11 @@ kotlin = "2.3.10"
 ktor = "3.4.1"
 logback = "1.5.32"
 logging = "8.0.01"
-micrometer = "1.16.3"
+micrometer = "1.16.4"
 pgjdbc = "0.8.9"
 postgres = "42.7.10"
 serialization = "1.10.0"
-utils = "2.6.0"
+utils = "2.6.1"
 
 [libraries]
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- config 6.0.7 → 6.0.9
- micrometer 1.16.3 → 1.16.4
- utils 2.6.0 → 2.6.1
- Gradle wrapper 9.2.0 → 9.4.0

## Test plan

- [ ] `./gradlew build` passes with updated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)