### PR TITLE
Migrate test framework from JUnit 5 + Kluent to Kotest 6 StringSpec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,21 @@ The admin UI uses HTMX (CDN) and Bootstrap (bundled static resources under `core
 
 ## Testing
 
-JUnit 5 + Kluent assertions + Ktor test host.
+Kotest 6 (`StringSpec` with `init {}`) + Kotest assertions + Ktor test host.
+
+All test classes extend `StringSpec()` and define tests as string-named lambdas inside an `init {}` block:
+
+```kotlin
+class MyTest : StringSpec() {
+  init {
+    "test name" {
+      result shouldBe expected
+    }
+  }
+}
+```
+
+Use `shouldBe`, `shouldContain`, `shouldThrow<T>`, `shouldNotBe`, etc. from `io.kotest.matchers.*`.
 
 - `vapi4k-core/src/test/kotlin/com/vapi4k/` - Unit tests for DSL builders, serialization, utilities
 - `vapi4k-core/src/test/kotlin/simpledemo/` - Example applications and integration tests

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ openAIModel {
 | **vapi4k-dbms**  | Optional database persistence (HikariCP + PostgreSQL + Exposed) |
 | **vapi4k-utils** | Shared utilities with zero external dependencies                |
 
+## Testing
+
+Tests use [Kotest 6](https://kotest.io) with `StringSpec` and Kotest assertions, plus the Ktor test host for
+integration tests. Run with:
+
+```bash
+./gradlew test
+```
+
 ## Documentation
 
 - [Vapi4k Documentation](https://vapi4k.com/overview.html)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ dokka = "2.1.0"
 exposed = "1.1.1"
 gradle-plugins = "1.0.8"
 hikari = "7.0.2"
-kluent = "1.73"
+kotest = "6.0.0.M4"
 kotlin = "2.3.10"
 ktor = "3.4.1"
 logback = "1.5.32"
@@ -54,7 +54,8 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-tests = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
-kluent = { module = "org.amshove.kluent:kluent", version.ref = "kluent" }
+kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 
 [plugins]
 jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.5.0.
 
-Key dependency versions: Kotlin 2.3.10, Ktor 3.4.1, Kotlinx Serialization 1.10.0, Exposed 1.1.1.
+Key dependency versions: Kotlin 2.3.10, Ktor 3.4.1, Kotlinx Serialization 1.10.0, Exposed 1.1.1, Kotest 6.0.0.M4.
 
 ## Modules
 

--- a/vapi4k-core/build.gradle.kts
+++ b/vapi4k-core/build.gradle.kts
@@ -65,7 +65,8 @@ dependencies {
     api(libs.exposed.kotlin.datetime)
 
     testImplementation(kotlin("test"))
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
     testImplementation(libs.ktor.server.tests)
     // testImplementation(libs.ktor.client.mock)
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ApiCalls.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ApiCalls.kt
@@ -18,84 +18,72 @@ package com.vapi4k
 
 import com.vapi4k.dsl.call.VapiApiImpl
 import com.vapi4k.dsl.call.VapiApiImpl.Companion.vapiApi
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
-class ApiCalls {
-  @Test
-  fun `Missing auth`() {
-    assertThrows(IllegalStateException::class.java) {
-      val api = vapiApi() as VapiApiImpl
-      api.test {
-        outboundCall {
+class ApiCalls : StringSpec() {
+  init {
+    "Missing auth" {
+      shouldThrow<IllegalStateException> {
+        val api = vapiApi() as VapiApiImpl
+        api.test {
+          outboundCall {
+          }
         }
-      }
-    }.also {
-      it.message.orEmpty().contains("VAPI_PRIVATE_KEY") shouldBeEqualTo true
+      }.message shouldContain "VAPI_PRIVATE_KEY"
     }
-  }
 
-  @Test
-  fun `Missing serverPath`() {
-    assertThrows(IllegalArgumentException::class.java) {
-      val api = vapiApi("123-445-666") as VapiApiImpl
-      api.test {
-        outboundCall {
+    "Missing serverPath" {
+      shouldThrow<IllegalArgumentException> {
+        val api = vapiApi("123-445-666") as VapiApiImpl
+        api.test {
+          outboundCall {
+          }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "serverPath must be assigned in outboundCall{}"
+      }.message shouldBe "serverPath must be assigned in outboundCall{}"
     }
-  }
 
-  @Test
-  fun `Missing phoneNumber`() {
-    assertThrows(IllegalArgumentException::class.java) {
-      val api = vapiApi("123-445-666") as VapiApiImpl
-      api.test {
-        outboundCall {
-          serverPath = "/outboundRequest"
+    "Missing phoneNumber" {
+      shouldThrow<IllegalArgumentException> {
+        val api = vapiApi("123-445-666") as VapiApiImpl
+        api.test {
+          outboundCall {
+            serverPath = "/outboundRequest"
+          }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "phoneNumber must be assigned in outboundCall{}"
+      }.message shouldBe "phoneNumber must be assigned in outboundCall{}"
     }
-  }
 
-  @Test
-  fun `Missing phoneNumberId`() {
-    assertThrows(IllegalStateException::class.java) {
-      val api = vapiApi("123-445-666") as VapiApiImpl
-      api.test {
-        outboundCall {
-          serverPath = "/outboundRequest"
-          phoneNumber = "+1123-456-7890"
+    "Missing phoneNumberId" {
+      shouldThrow<IllegalStateException> {
+        val api = vapiApi("123-445-666") as VapiApiImpl
+        api.test {
+          outboundCall {
+            serverPath = "/outboundRequest"
+            phoneNumber = "+1123-456-7890"
+          }
         }
-      }
-    }.also {
-      it.message.orEmpty().contains("Missing phoneNumberId value") shouldBeEqualTo true
+      }.message shouldContain "Missing phoneNumberId value"
     }
-  }
 
-  @Test
-  fun `multiple outboundCall{} blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      val api = vapiApi("123-445-666") as VapiApiImpl
-      api.test {
-        outboundCall {
-          serverPath = "/outboundRequest1"
-          phoneNumber = "+1123-456-7890"
-          phoneNumberId = "123-445-666"
+    "multiple outboundCall{} blocks" {
+      shouldThrow<IllegalStateException> {
+        val api = vapiApi("123-445-666") as VapiApiImpl
+        api.test {
+          outboundCall {
+            serverPath = "/outboundRequest1"
+            phoneNumber = "+1123-456-7890"
+            phoneNumberId = "123-445-666"
+          }
+          outboundCall {
+            serverPath = "/outboundRequest2"
+            phoneNumber = "+1123-456-7890"
+            phoneNumberId = "123-445-666"
+          }
         }
-        outboundCall {
-          serverPath = "/outboundRequest2"
-          phoneNumber = "+1123-456-7890"
-          phoneNumberId = "123-445-666"
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "outboundCall{} was already called"
+      }.message shouldBe "outboundCall{} was already called"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ApplicationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ApplicationTest.kt
@@ -18,65 +18,60 @@ package com.vapi4k
 
 import com.vapi4k.common.CoreEnvVars.defaultServerPath
 import com.vapi4k.dsl.vapi4k.Vapi4kConfigImpl
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
-class ApplicationTest {
-  @Test
-  fun `test for serverPath and serverSecret`() {
-    val str = "/something_else"
-    val app =
-      with(Vapi4kConfigImpl()) {
-        inboundCallApplication {
-          serverPath = str
-          serverSecret = "12345"
+class ApplicationTest : StringSpec() {
+  init {
+    "test for serverPath and serverSecret" {
+      val str = "/something_else"
+      val app =
+        with(Vapi4kConfigImpl()) {
+          inboundCallApplication {
+            serverPath = str
+            serverSecret = "12345"
+          }
         }
-      }
-    app.serverPath shouldBeEqualTo str
-    app.serverSecret shouldBeEqualTo "12345"
-  }
-
-  @Test
-  fun `test for default serverPath`() {
-    val app =
-      with(Vapi4kConfigImpl()) {
-        inboundCallApplication {
-        }
-      }
-    app.serverPath shouldBeEqualTo defaultServerPath.removePrefix("/")
-    app.serverSecret shouldBeEqualTo ""
-  }
-
-  @Test
-  fun `test for duplicate default serverPaths`() {
-    val str = "/something_else"
-    assertThrows(IllegalStateException::class.java) {
-      with(Vapi4kConfigImpl()) {
-        inboundCallApplication {
-        }
-        inboundCallApplication {
-        }
-      }
-    }.also {
-      it.message.orEmpty().contains("already exists") shouldBeEqualTo true
+      app.serverPath shouldBe str
+      app.serverSecret shouldBe "12345"
     }
-  }
 
-  @Test
-  fun `test for duplicate serverPaths`() {
-    val str = "/something_else"
-    assertThrows(IllegalStateException::class.java) {
-      with(Vapi4kConfigImpl()) {
-        inboundCallApplication {
-          serverPath = str
+    "test for default serverPath" {
+      val app =
+        with(Vapi4kConfigImpl()) {
+          inboundCallApplication {
+          }
         }
-        inboundCallApplication {
-          serverPath = str
+      app.serverPath shouldBe defaultServerPath.removePrefix("/")
+      app.serverSecret shouldBe ""
+    }
+
+    "test for duplicate default serverPaths" {
+      val str = "/something_else"
+      shouldThrow<IllegalStateException> {
+        with(Vapi4kConfigImpl()) {
+          inboundCallApplication {
+          }
+          inboundCallApplication {
+          }
         }
-      }
-    }.also {
-      it.message.orEmpty().contains("already exists") shouldBeEqualTo true
+      }.message shouldContain "already exists"
+    }
+
+    "test for duplicate serverPaths" {
+      val str = "/something_else"
+      shouldThrow<IllegalStateException> {
+        with(Vapi4kConfigImpl()) {
+          inboundCallApplication {
+            serverPath = str
+          }
+          inboundCallApplication {
+            serverPath = str
+          }
+        }
+      }.message shouldContain "already exists"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ApplicationTypeTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ApplicationTypeTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.dsl.vapi4k.ApplicationType
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+
+class ApplicationTypeTest : StringSpec() {
+  init {
+    "INBOUND_CALL getRandomSessionId ends with InboundCall" {
+      val sessionId = ApplicationType.INBOUND_CALL.getRandomSessionId()
+      sessionId.value shouldContain "-InboundCall"
+      sessionId.value shouldEndWith "-InboundCall"
+    }
+
+    "OUTBOUND_CALL getRandomSessionId ends with OutboundCall" {
+      val sessionId = ApplicationType.OUTBOUND_CALL.getRandomSessionId()
+      sessionId.value shouldEndWith "-OutboundCall"
+    }
+
+    "WEB getRandomSessionId ends with Web" {
+      val sessionId = ApplicationType.WEB.getRandomSessionId()
+      sessionId.value shouldEndWith "-Web"
+    }
+
+    "getRandomSessionId produces unique values" {
+      val id1 = ApplicationType.INBOUND_CALL.getRandomSessionId()
+      val id2 = ApplicationType.INBOUND_CALL.getRandomSessionId()
+      id1 shouldNotBe id2
+    }
+
+    "getRandomSessionId has expected format with dashes" {
+      val sessionId = ApplicationType.INBOUND_CALL.getRandomSessionId()
+      val parts = sessionId.value.split("-")
+      (parts.size >= 5) shouldBe true
+    }
+
+    "functionName includes braces" {
+      ApplicationType.INBOUND_CALL.functionName shouldBe "inboundCallApplication{}"
+      ApplicationType.OUTBOUND_CALL.functionName shouldBe "outboundCallApplication{}"
+      ApplicationType.WEB.functionName shouldBe "webApplication{}"
+    }
+
+    "displayName values are correct" {
+      ApplicationType.INBOUND_CALL.displayName shouldBe "inboundCallApplication"
+      ApplicationType.OUTBOUND_CALL.displayName shouldBe "outboundCallApplication"
+      ApplicationType.WEB.displayName shouldBe "webApplication"
+    }
+
+    "pathPrefix values are correct" {
+      ApplicationType.INBOUND_CALL.pathPrefix shouldBe "inboundCall"
+      ApplicationType.OUTBOUND_CALL.pathPrefix shouldBe "outboundCall"
+      ApplicationType.WEB.pathPrefix shouldBe "web"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/AssistantTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/AssistantTest.kt
@@ -41,15 +41,15 @@ import com.vapi4k.utils.JsonFilenames.JSON_ASSISTANT_REQUEST
 import com.vapi4k.utils.assistantResponse
 import com.vapi4k.utils.firstMessageOfType
 import com.vapi4k.utils.withTestApplication
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.json.JsonElement
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
 
-class AssistantTest {
-  init {
-    Vapi4kConfigImpl()
-  }
+class AssistantTest : StringSpec() {
+  @Suppress("unused")
+  private val configInit = Vapi4kConfigImpl()
 
   private val messageOne = "Hi there test"
   private val sysMessage = "You are the test systemMessage voice"
@@ -69,665 +69,619 @@ class AssistantTest {
   val JsonElement.assistantClientMessages get() = jsonElementList("messageResponse.assistant.clientMessages")
   val JsonElement.assistantServerMessages get() = jsonElementList("messageResponse.assistant.serverMessages")
 
-  @Test
-  fun testRegular() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+  init {
+    "testRegular" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 2000
-                }
-              }
-            }
-          }
-        }
-      }
-
-    jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START)
-      .stringValue("content") shouldBeEqualTo "This is the test request start message"
-  }
-
-  @Test
-  fun `multiple application{} blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = "Something"
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-        assistant {
-          firstMessage = "Something"
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "assistant{} was already called"
-    }
-  }
-
-  @Test
-  fun `application{} and squad{} blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = "Something"
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-        assistantId {
-          id = "12345"
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "assistant{} was already called"
-    }
-  }
-
-  @Test
-  fun `Missing application{} blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-      }
-    }.also {
-      val msg = "assistantResponse{} is missing a call to assistant{}, assistantId{}, squad{}, or squadId{}"
-      it.message shouldBeEqualTo msg
-    }
-  }
-
-  @Test
-  fun `test reverse delay order`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 2000
-                }
-              }
-            }
-          }
-        }
-      }
-    with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
-      stringValue("content") shouldBeEqualTo delayedMessage
-      intValue("timingMilliseconds") shouldBeEqualTo 2000
-    }
-  }
-
-  @Test
-  fun `test message with no millis`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 99
-                }
-              }
-            }
-          }
-        }
-      }
-    jsonElement
-      .firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
-      .intValue("timingMilliseconds") shouldBeEqualTo 99
-  }
-
-  @Test
-  fun `multiple message`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  content = secondDelayedMessage
-                  timingMilliseconds = 2000
-                }
-              }
-            }
-          }
-        }
-      }
-
-    with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
-      stringValue("content") shouldBeEqualTo secondDelayedMessage
-      intValue("timingMilliseconds") shouldBeEqualTo 2000
-    }
-  }
-
-  @Test
-  fun `multiple delay time`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 2000
-                  timingMilliseconds = 1000
-                }
-              }
-            }
-          }
-        }
-      }
-
-    // println(jsonElement.toJsonString())
-
-    jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
-      .intValue("timingMilliseconds") shouldBeEqualTo 1000
-  }
-
-  @Test
-  fun `multiple message multiple delay time`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  content = secondDelayedMessage
-                  timingMilliseconds = 2000
-                  timingMilliseconds = 1000
-                }
-              }
-            }
-          }
-        }
-      }
-    with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
-      stringValue("content") shouldBeEqualTo secondDelayedMessage
-      intValue("timingMilliseconds") shouldBeEqualTo 1000
-    }
-  }
-
-  @Test
-  fun `chicago illinois message`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                condition("city" eq "Chicago", "state" eq "Illinois") {
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
                   requestStartMessage {
-                    content = chicagoIllinoisStartMessage
+                    content = startMessage
                   }
                   requestCompleteMessage {
-                    content = chicagoIllinoisCompleteMessage
+                    content = completeMessage
                   }
                   requestFailedMessage {
-                    content = chicagoIllinoisFailedMessage
+                    content = failedMessage
                   }
                   requestDelayedMessage {
-                    content = chicagoIllinoisDelayedMessage
+                    content = delayedMessage
                     timingMilliseconds = 2000
                   }
                 }
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 1000
-                }
               }
             }
           }
         }
-      }
 
-    val chicagoCity = "city" eq "Chicago"
-    val illinoisState = "state" eq "Illinois"
-
-    val chicagoStartMessage =
-      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START, chicagoCity, illinoisState)
-
-    val chicagoCompleteMessage =
-      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_COMPLETE, chicagoCity, illinoisState)
-
-    val chicagoFailedMessage =
-      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_FAILED, chicagoCity, illinoisState)
-
-    val chicagoDelayedMessage =
-      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED, chicagoCity, illinoisState)
-
-    val defaultStartMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START)
-    val defaultCompleteMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_COMPLETE)
-    val defaultFailedMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_FAILED)
-    val defaultDelayedMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
-
-    chicagoStartMessage.stringValue("content") shouldBeEqualTo chicagoIllinoisStartMessage
-    chicagoCompleteMessage.stringValue("content") shouldBeEqualTo chicagoIllinoisCompleteMessage
-    chicagoFailedMessage.stringValue("content") shouldBeEqualTo chicagoIllinoisFailedMessage
-    chicagoDelayedMessage.stringValue("content") shouldBeEqualTo chicagoIllinoisDelayedMessage
-    chicagoDelayedMessage.intValue("timingMilliseconds") shouldBeEqualTo 2000
-    defaultStartMessage.stringValue("content") shouldBeEqualTo startMessage
-    defaultCompleteMessage.stringValue("content") shouldBeEqualTo completeMessage
-    defaultFailedMessage.stringValue("content") shouldBeEqualTo failedMessage
-    defaultDelayedMessage.stringValue("content") shouldBeEqualTo delayedMessage
-    defaultDelayedMessage.intValue("timingMilliseconds") shouldBeEqualTo 1000
-  }
-
-  @Test
-  fun `Missing message`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                condition("city" eq "Chicago", "state" eq "Illinois") {
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      assert(it.message.orEmpty().contains("must have at least one message"))
+      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START)
+        .stringValue("content") shouldBe "This is the test request start message"
     }
-  }
 
-  @Test
-  fun `error on duplicate reverse conditions`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = messageOne
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "multiple application{} blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = "Something"
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+          assistant {
+            firstMessage = "Something"
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+      }.message shouldBe "assistant{} was already called"
+    }
 
-            systemMessage = sysMessage
-            tools {
-              serviceTool(FavoriteFoodService()) {
-                condition("city" eq "Chicago", "state" eq "Illinois") {
+    "application{} and squad{} blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = "Something"
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+          assistantId {
+            id = "12345"
+          }
+        }
+      }.message shouldBe "assistant{} was already called"
+    }
+
+    "Missing application{} blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+        }
+      }.message shouldBe "assistantResponse{} is missing a call to assistant{}, assistantId{}, squad{}, or squadId{}"
+    }
+
+    "test reverse delay order" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
                   requestStartMessage {
-                    content = chicagoIllinoisStartMessage
+                    content = startMessage
                   }
                   requestCompleteMessage {
-                    content = chicagoIllinoisCompleteMessage
+                    content = completeMessage
                   }
                   requestFailedMessage {
-                    content = chicagoIllinoisFailedMessage
+                    content = failedMessage
                   }
                   requestDelayedMessage {
-                    content = chicagoIllinoisDelayedMessage
+                    content = delayedMessage
                     timingMilliseconds = 2000
                   }
                 }
-                condition("state" eq "Illinois", "city" eq "Chicago") {
+              }
+            }
+          }
+        }
+      with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
+        stringValue("content") shouldBe delayedMessage
+        intValue("timingMilliseconds") shouldBe 2000
+      }
+    }
+
+    "test message with no millis" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
                   requestStartMessage {
-                    content = chicagoIllinoisStartMessage + "2"
+                    content = startMessage
                   }
                   requestCompleteMessage {
-                    content = chicagoIllinoisCompleteMessage + "2"
+                    content = completeMessage
                   }
                   requestFailedMessage {
-                    content = chicagoIllinoisFailedMessage + "2"
+                    content = failedMessage
                   }
                   requestDelayedMessage {
-                    content = chicagoIllinoisDelayedMessage + "2"
-                    timingMilliseconds = 3000
+                    content = delayedMessage
+                    timingMilliseconds = 99
                   }
-                }
-                requestStartMessage {
-                  content = startMessage
-                }
-                requestCompleteMessage {
-                  content = completeMessage
-                }
-                requestFailedMessage {
-                  content = failedMessage
-                }
-                requestDelayedMessage {
-                  content = delayedMessage
-                  timingMilliseconds = 1000
                 }
               }
             }
           }
         }
-      }
-    }.also {
-      assert(it.message.orEmpty().contains("duplicates an existing condition{}"))
+      jsonElement
+        .firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
+        .intValue("timingMilliseconds") shouldBe 99
     }
-  }
 
-  @Test
-  fun `check non-default FirstMessageModeType values`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessageMode = ASSISTANT_SPEAKS_FIRST_WITH_MODEL_GENERATED_MODEL
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "multiple message" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  requestStartMessage {
+                    content = startMessage
+                  }
+                  requestCompleteMessage {
+                    content = completeMessage
+                  }
+                  requestFailedMessage {
+                    content = failedMessage
+                  }
+                  requestDelayedMessage {
+                    content = delayedMessage
+                    content = secondDelayedMessage
+                    timingMilliseconds = 2000
+                  }
+                }
+              }
+            }
           }
         }
+
+      with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
+        stringValue("content") shouldBe secondDelayedMessage
+        intValue("timingMilliseconds") shouldBe 2000
       }
-
-    val msg = assistant.toJsonElement().stringValue("messageResponse.assistant.firstMessageMode")
-    msg shouldBeEqualTo ASSISTANT_SPEAKS_FIRST_WITH_MODEL_GENERATED_MODEL.desc
-  }
-
-  @Test
-  fun `check assistant client messages 1`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          clientMessages -= AssistantClientMessageType.HANG
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-      }
-
-    val element = assistant.toJsonElement()
-    element.assistantClientMessages.size shouldBeEqualTo 9
-  }
-
-  @Test
-  fun `check assistant client messages 2`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          clientMessages -= setOf(AssistantClientMessageType.HANG, AssistantClientMessageType.STATUS_UPDATE)
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-      }
-
-    val element = assistant.toJsonElement()
-    element.assistantClientMessages.size shouldBeEqualTo 8
-  }
-
-  @Test
-  fun `check assistant server messages 1`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = "Something"
-          serverMessages -= AssistantServerMessageType.HANG
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-      }
-
-    val element = assistant.toJsonElement()
-    element.assistantServerMessages.size shouldBeEqualTo 8
-  }
-
-  @Test
-  fun `check assistant server messages 2`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          serverMessages -= setOf(AssistantServerMessageType.HANG, AssistantServerMessageType.SPEECH_UPDATE)
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-        }
-      }
-
-    val element = assistant.toJsonElement()
-    element.assistantServerMessages.size shouldBeEqualTo 7
-  }
-
-  @Test
-  fun `multiple deepgram transcriber blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-          }
-
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "deepgramTranscriber{} requires a transcriberLanguage or customLanguagevalue"
     }
-  }
 
-  @Test
-  fun `multiple gladia transcriber blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          gladiaTranscriber {
-            transcriberModel = GladiaModelType.FAST
-          }
+    "multiple delay time" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-          gladiaTranscriber {
-            transcriberModel = GladiaModelType.FAST
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  requestStartMessage {
+                    content = startMessage
+                  }
+                  requestCompleteMessage {
+                    content = completeMessage
+                  }
+                  requestFailedMessage {
+                    content = failedMessage
+                  }
+                  requestDelayedMessage {
+                    content = delayedMessage
+                    timingMilliseconds = 2000
+                    timingMilliseconds = 1000
+                  }
+                }
+              }
+            }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "gladiaTranscriber{} requires a transcriberLanguage or customLanguage value"
+
+      // println(jsonElement.toJsonString())
+
+      jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
+        .intValue("timingMilliseconds") shouldBe 1000
     }
-  }
 
-  @Test
-  fun `multiple talkscriber transcriber blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          talkscriberTranscriber {
-            transcriberModel = TalkscriberModelType.WHISPER
-          }
-
-          talkscriberTranscriber {
-            transcriberModel = TalkscriberModelType.WHISPER
+    "multiple message multiple delay time" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  requestStartMessage {
+                    content = startMessage
+                  }
+                  requestCompleteMessage {
+                    content = completeMessage
+                  }
+                  requestFailedMessage {
+                    content = failedMessage
+                  }
+                  requestDelayedMessage {
+                    content = delayedMessage
+                    content = secondDelayedMessage
+                    timingMilliseconds = 2000
+                    timingMilliseconds = 1000
+                  }
+                }
+              }
+            }
           }
         }
+      with(jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)) {
+        stringValue("content") shouldBe secondDelayedMessage
+        intValue("timingMilliseconds") shouldBe 1000
       }
-    }.also {
-      it.message shouldBeEqualTo "talkscriberTranscriber{} requires a transcriberLanguage or customLanguage value"
     }
-  }
 
-  @Test
-  fun `multiple transcriber blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          talkscriberTranscriber {
-            transcriberModel = TalkscriberModelType.WHISPER
-          }
-
-          gladiaTranscriber {
-            transcriberModel = GladiaModelType.FAST
+    "chicago illinois message" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JSON_ASSISTANT_REQUEST) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  condition("city" eq "Chicago", "state" eq "Illinois") {
+                    requestStartMessage {
+                      content = chicagoIllinoisStartMessage
+                    }
+                    requestCompleteMessage {
+                      content = chicagoIllinoisCompleteMessage
+                    }
+                    requestFailedMessage {
+                      content = chicagoIllinoisFailedMessage
+                    }
+                    requestDelayedMessage {
+                      content = chicagoIllinoisDelayedMessage
+                      timingMilliseconds = 2000
+                    }
+                  }
+                  requestStartMessage {
+                    content = startMessage
+                  }
+                  requestCompleteMessage {
+                    content = completeMessage
+                  }
+                  requestFailedMessage {
+                    content = failedMessage
+                  }
+                  requestDelayedMessage {
+                    content = delayedMessage
+                    timingMilliseconds = 1000
+                  }
+                }
+              }
+            }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "talkscriberTranscriber{} requires a transcriberLanguage or customLanguage value"
+
+      val chicagoCity = "city" eq "Chicago"
+      val illinoisState = "state" eq "Illinois"
+
+      val chicagoStartMessage =
+        jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START, chicagoCity, illinoisState)
+
+      val chicagoCompleteMessage =
+        jsonElement.firstMessageOfType(ToolMessageType.REQUEST_COMPLETE, chicagoCity, illinoisState)
+
+      val chicagoFailedMessage =
+        jsonElement.firstMessageOfType(ToolMessageType.REQUEST_FAILED, chicagoCity, illinoisState)
+
+      val chicagoDelayedMessage =
+        jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED, chicagoCity, illinoisState)
+
+      val defaultStartMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_START)
+      val defaultCompleteMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_COMPLETE)
+      val defaultFailedMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_FAILED)
+      val defaultDelayedMessage = jsonElement.firstMessageOfType(ToolMessageType.REQUEST_RESPONSE_DELAYED)
+
+      chicagoStartMessage.stringValue("content") shouldBe chicagoIllinoisStartMessage
+      chicagoCompleteMessage.stringValue("content") shouldBe chicagoIllinoisCompleteMessage
+      chicagoFailedMessage.stringValue("content") shouldBe chicagoIllinoisFailedMessage
+      chicagoDelayedMessage.stringValue("content") shouldBe chicagoIllinoisDelayedMessage
+      chicagoDelayedMessage.intValue("timingMilliseconds") shouldBe 2000
+      defaultStartMessage.stringValue("content") shouldBe startMessage
+      defaultCompleteMessage.stringValue("content") shouldBe completeMessage
+      defaultFailedMessage.stringValue("content") shouldBe failedMessage
+      defaultDelayedMessage.stringValue("content") shouldBe delayedMessage
+      defaultDelayedMessage.intValue("timingMilliseconds") shouldBe 1000
     }
-  }
 
-  @Test
-  fun `deepgram transcriber enum value`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-            transcriberLanguage = DeepgramLanguageType.GERMAN
+    "Missing message" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  condition("city" eq "Chicago", "state" eq "Illinois") {
+                  }
+                }
+              }
+            }
           }
         }
-      }
-    val je = assistant.toJsonElement()
-    je.stringValue("messageResponse.assistant.transcriber.language") shouldBeEqualTo DeepgramLanguageType.GERMAN.desc
-  }
-
-  @Test
-  fun `deepgram transcriber custom value`() {
-    val assistant =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-            customLanguage = "zzz"
-          }
-        }
-      }
-    val jsonElement = assistant.toJsonElement()
-    jsonElement.stringValue("messageResponse.assistant.transcriber.language") shouldBeEqualTo "zzz"
-  }
-
-  @Test
-  fun `deepgram transcriber conflicting values`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-            transcriberLanguage = DeepgramLanguageType.GERMAN
-            customLanguage = "zzz"
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "deepgramTranscriber{} cannot have both transcriberLanguage and customLanguage values"
+      }.message shouldContain "must have at least one message"
     }
-  }
 
-  @Test
-  fun `missing model decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          firstMessage = "Something"
+    "error on duplicate reverse conditions" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = messageOne
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+
+              systemMessage = sysMessage
+              tools {
+                serviceTool(FavoriteFoodService()) {
+                  condition("city" eq "Chicago", "state" eq "Illinois") {
+                    requestStartMessage {
+                      content = chicagoIllinoisStartMessage
+                    }
+                    requestCompleteMessage {
+                      content = chicagoIllinoisCompleteMessage
+                    }
+                    requestFailedMessage {
+                      content = chicagoIllinoisFailedMessage
+                    }
+                    requestDelayedMessage {
+                      content = chicagoIllinoisDelayedMessage
+                      timingMilliseconds = 2000
+                    }
+                  }
+                  condition("state" eq "Illinois", "city" eq "Chicago") {
+                    requestStartMessage {
+                      content = chicagoIllinoisStartMessage + "2"
+                    }
+                    requestCompleteMessage {
+                      content = chicagoIllinoisCompleteMessage + "2"
+                    }
+                    requestFailedMessage {
+                      content = chicagoIllinoisFailedMessage + "2"
+                    }
+                    requestDelayedMessage {
+                      content = chicagoIllinoisDelayedMessage + "2"
+                      timingMilliseconds = 3000
+                    }
+                  }
+                  requestStartMessage {
+                    content = startMessage
+                  }
+                  requestCompleteMessage {
+                    content = completeMessage
+                  }
+                  requestFailedMessage {
+                    content = failedMessage
+                  }
+                  requestDelayedMessage {
+                    content = delayedMessage
+                    timingMilliseconds = 1000
+                  }
+                }
+              }
+            }
+          }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "An assistant{} requires a model{} decl"
+      }.message shouldContain "duplicates an existing condition{}"
+    }
+
+    "check non-default FirstMessageModeType values" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessageMode = ASSISTANT_SPEAKS_FIRST_WITH_MODEL_GENERATED_MODEL
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+
+      val msg = assistant.toJsonElement().stringValue("messageResponse.assistant.firstMessageMode")
+      msg shouldBe ASSISTANT_SPEAKS_FIRST_WITH_MODEL_GENERATED_MODEL.desc
+    }
+
+    "check assistant client messages 1" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            clientMessages -= AssistantClientMessageType.HANG
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+
+      val element = assistant.toJsonElement()
+      element.assistantClientMessages.size shouldBe 9
+    }
+
+    "check assistant client messages 2" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            clientMessages -= setOf(AssistantClientMessageType.HANG, AssistantClientMessageType.STATUS_UPDATE)
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+
+      val element = assistant.toJsonElement()
+      element.assistantClientMessages.size shouldBe 8
+    }
+
+    "check assistant server messages 1" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = "Something"
+            serverMessages -= AssistantServerMessageType.HANG
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+
+      val element = assistant.toJsonElement()
+      element.assistantServerMessages.size shouldBe 8
+    }
+
+    "check assistant server messages 2" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            serverMessages -= setOf(AssistantServerMessageType.HANG, AssistantServerMessageType.SPEECH_UPDATE)
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+          }
+        }
+
+      val element = assistant.toJsonElement()
+      element.assistantServerMessages.size shouldBe 7
+    }
+
+    "multiple deepgram transcriber blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+            }
+
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+            }
+          }
+        }
+      }.message shouldBe "deepgramTranscriber{} requires a transcriberLanguage or customLanguagevalue"
+    }
+
+    "multiple gladia transcriber blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            gladiaTranscriber {
+              transcriberModel = GladiaModelType.FAST
+            }
+
+            gladiaTranscriber {
+              transcriberModel = GladiaModelType.FAST
+            }
+          }
+        }
+      }.message shouldBe "gladiaTranscriber{} requires a transcriberLanguage or customLanguage value"
+    }
+
+    "multiple talkscriber transcriber blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            talkscriberTranscriber {
+              transcriberModel = TalkscriberModelType.WHISPER
+            }
+
+            talkscriberTranscriber {
+              transcriberModel = TalkscriberModelType.WHISPER
+            }
+          }
+        }
+      }.message shouldBe "talkscriberTranscriber{} requires a transcriberLanguage or customLanguage value"
+    }
+
+    "multiple transcriber blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            talkscriberTranscriber {
+              transcriberModel = TalkscriberModelType.WHISPER
+            }
+
+            gladiaTranscriber {
+              transcriberModel = GladiaModelType.FAST
+            }
+          }
+        }
+      }.message shouldBe "talkscriberTranscriber{} requires a transcriberLanguage or customLanguage value"
+    }
+
+    "deepgram transcriber enum value" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+              transcriberLanguage = DeepgramLanguageType.GERMAN
+            }
+          }
+        }
+      val je = assistant.toJsonElement()
+      je.stringValue("messageResponse.assistant.transcriber.language") shouldBe DeepgramLanguageType.GERMAN.desc
+    }
+
+    "deepgram transcriber custom value" {
+      val assistant =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+              customLanguage = "zzz"
+            }
+          }
+        }
+      val jsonElement = assistant.toJsonElement()
+      jsonElement.stringValue("messageResponse.assistant.transcriber.language") shouldBe "zzz"
+    }
+
+    "deepgram transcriber conflicting values" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+              transcriberLanguage = DeepgramLanguageType.GERMAN
+              customLanguage = "zzz"
+            }
+          }
+        }
+      }.message shouldBe "deepgramTranscriber{} cannot have both transcriberLanguage and customLanguage values"
+    }
+
+    "missing model decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            firstMessage = "Something"
+          }
+        }
+      }.message shouldBe "An assistant{} requires a model{} decl"
     }
   }
 

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/BaseToolMessageTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/BaseToolMessageTest.kt
@@ -22,30 +22,31 @@ import com.vapi4k.api.model.OpenAIModelType
 import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
 import com.vapi4k.utils.JsonFilenames
 import com.vapi4k.utils.withTestApplication
-import org.amshove.kluent.shouldBeEqualTo
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class BaseToolMessageTest {
-  @Test
-  fun `toolMessageStart test`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JsonFilenames.JSON_ASSISTANT_REQUEST) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "assistant 1"
-                firstMessage = "I'm assistant 1"
+class BaseToolMessageTest : StringSpec() {
+  init {
+    "toolMessageStart test" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JsonFilenames.JSON_ASSISTANT_REQUEST) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "assistant 1"
+                  firstMessage = "I'm assistant 1"
 
-                openAIModel {
-                  modelType = OpenAIModelType.GPT_4_TURBO
-                  tools {
-                    serviceTool(WeatherLookupService1()) {
-                      requestStartMessage {
-                        content = "tool 1 start message"
-                      }
-                      requestCompleteMessage {
-                        content = "tool 1 complete message"
+                  openAIModel {
+                    modelType = OpenAIModelType.GPT_4_TURBO
+                    tools {
+                      serviceTool(WeatherLookupService1()) {
+                        requestStartMessage {
+                          content = "tool 1 start message"
+                        }
+                        requestCompleteMessage {
+                          content = "tool 1 complete message"
+                        }
                       }
                     }
                   }
@@ -54,15 +55,15 @@ class BaseToolMessageTest {
             }
           }
         }
-      }
 
-    response.status.value shouldBeEqualTo 200
-    val assistantTools =
-      jsonElement
-        .jsonElementList("messageResponse.squad.members")
-        .first()
-        .jsonElementList("assistant.model.tools")
-    assistantTools.first().jsonElementList("messages").first()
-      .stringValue("content") shouldBeEqualTo "tool 1 start message"
+      response.status.value shouldBe 200
+      val assistantTools =
+        jsonElement
+          .jsonElementList("messageResponse.squad.members")
+          .first()
+          .jsonElementList("assistant.model.tools")
+      assistantTools.first().jsonElementList("messages").first()
+        .stringValue("content") shouldBe "tool 1 start message"
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/DuplicateInvokeCheckerTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/DuplicateInvokeCheckerTest.kt
@@ -17,50 +17,40 @@
 package com.vapi4k
 
 import com.vapi4k.common.DuplicateInvokeChecker
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class DuplicateInvokeCheckerTest {
-  @Test
-  fun `wasCalled is false before any call`() {
-    val checker = DuplicateInvokeChecker()
-    checker.wasCalled.shouldBeFalse()
-  }
-
-  @Test
-  fun `first call succeeds and sets wasCalled`() {
-    val checker = DuplicateInvokeChecker()
-    checker.check("assistant{} was already called")
-    checker.wasCalled.shouldBeTrue()
-  }
-
-  @Test
-  fun `second call throws with first message`() {
-    val checker = DuplicateInvokeChecker()
-    checker.check("assistant{} was already called")
-    assertThrows(IllegalStateException::class.java) {
-      checker.check("this message is ignored")
-    }.also {
-      it.message shouldBeEqualTo "assistant{} was already called"
+class DuplicateInvokeCheckerTest : StringSpec() {
+  init {
+    "wasCalled is false before any call" {
+      val checker = DuplicateInvokeChecker()
+      checker.wasCalled shouldBe false
     }
-  }
 
-  @Test
-  fun `third call also throws with first message`() {
-    val checker = DuplicateInvokeChecker()
-    checker.check("first error message")
-    assertThrows(IllegalStateException::class.java) {
-      checker.check("second")
-    }.also {
-      it.message shouldBeEqualTo "first error message"
+    "first call succeeds and sets wasCalled" {
+      val checker = DuplicateInvokeChecker()
+      checker.check("assistant{} was already called")
+      checker.wasCalled shouldBe true
     }
-    assertThrows(IllegalStateException::class.java) {
-      checker.check("third")
-    }.also {
-      it.message shouldBeEqualTo "first error message"
+
+    "second call throws with first message" {
+      val checker = DuplicateInvokeChecker()
+      checker.check("assistant{} was already called")
+      shouldThrow<IllegalStateException> {
+        checker.check("this message is ignored")
+      }.message shouldBe "assistant{} was already called"
+    }
+
+    "third call also throws with first message" {
+      val checker = DuplicateInvokeChecker()
+      checker.check("first error message")
+      shouldThrow<IllegalStateException> {
+        checker.check("second")
+      }.message shouldBe "first error message"
+      shouldThrow<IllegalStateException> {
+        checker.check("third")
+      }.message shouldBe "first error message"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/EOCRCacheTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/EOCRCacheTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.github.pambrose.common.json.get
+import com.github.pambrose.common.json.intValue
+import com.github.pambrose.common.json.keys
+import com.vapi4k.DoubleToolAssistant.doubleToolAssistant
+import com.vapi4k.common.CoreEnvVars.defaultServerPath
+import com.vapi4k.common.Endpoints.CACHES_PATH
+import com.vapi4k.common.Utils.ensureStartsWith
+import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
+import com.vapi4k.utils.withTestApplication
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode
+
+class EOCRCacheTest : StringSpec() {
+  init {
+    "processEOCRMessage removes cache entries when eocrCacheRemovalEnabled is true" {
+      val responses =
+        withTestApplication(
+          INBOUND_CALL,
+          listOf(
+            "/json-tool-tests/assistantRequest.json",
+            "/json-tool-tests/endOfCallReportRequest.json",
+          ),
+          CACHES_PATH,
+          true,
+        ) {
+          doubleToolAssistant()
+        }
+      responses.forEach { (response, _) ->
+        response.status shouldBe HttpStatusCode.OK
+      }
+      val cachesResponse = responses.last()
+      val jsonElement = cachesResponse.second
+      val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
+      jsonElement.intValue("$path.serviceTools.cacheSize") shouldBeLessThan 2
+    }
+
+    "processEOCRMessage preserves cache entries when eocrCacheRemovalEnabled is false" {
+      val responses =
+        withTestApplication(
+          INBOUND_CALL,
+          listOf(
+            "/json-tool-tests/assistantRequest.json",
+            "/json-tool-tests/endOfCallReportRequest.json",
+          ),
+          CACHES_PATH,
+          false,
+        ) {
+          doubleToolAssistant()
+        }
+      responses.forEach { (response, _) ->
+        response.status shouldBe HttpStatusCode.OK
+      }
+      val cachesResponse = responses.last()
+      val jsonElement = cachesResponse.second
+      val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
+      jsonElement["$path.serviceTools.cache"].keys.size shouldBe 2
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/EnumSerializationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/EnumSerializationTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.api.model.AnthropicModelType
+import com.vapi4k.api.model.GroqModelType
+import com.vapi4k.api.model.OpenAIModelType
+import com.vapi4k.api.voice.AzureVoiceIdType
+import com.vapi4k.api.voice.DeepGramVoiceIdType
+import com.vapi4k.api.voice.ElevenLabsVoiceIdType
+import com.vapi4k.api.voice.LMNTVoiceIdType
+import com.vapi4k.api.voice.NeetsVoiceIdType
+import com.vapi4k.api.voice.OpenAIVoiceIdType
+import com.vapi4k.api.voice.PlayHTVoiceIdType
+import com.vapi4k.api.voice.RimeAIVoiceIdType
+import com.vapi4k.common.Constants.UNSPECIFIED_DEFAULT
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class EnumSerializationTest : StringSpec() {
+  private fun <T> assertUniqueDescs(
+    entries: List<T>,
+    descExtractor: (T) -> String,
+  ) {
+    val descs = entries.map(descExtractor)
+    descs.size shouldBe descs.toSet().size
+  }
+
+  init {
+    "OpenAIModelType entries have unique desc values" {
+      assertUniqueDescs(OpenAIModelType.entries) { it.desc }
+    }
+
+    "AnthropicModelType entries have unique desc values" {
+      assertUniqueDescs(AnthropicModelType.entries) { it.desc }
+    }
+
+    "GroqModelType entries have unique desc values" {
+      assertUniqueDescs(GroqModelType.entries) { it.desc }
+    }
+
+    "ElevenLabsVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(ElevenLabsVoiceIdType.entries) { it.desc }
+    }
+
+    "PlayHTVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(PlayHTVoiceIdType.entries) { it.desc }
+    }
+
+    "DeepGramVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(DeepGramVoiceIdType.entries) { it.desc }
+    }
+
+    "OpenAIVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(OpenAIVoiceIdType.entries) { it.desc }
+    }
+
+    "AzureVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(AzureVoiceIdType.entries) { it.desc }
+    }
+
+    "LMNTVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(LMNTVoiceIdType.entries) { it.desc }
+    }
+
+    "RimeAIVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(RimeAIVoiceIdType.entries) { it.desc }
+    }
+
+    "NeetsVoiceIdType entries have unique desc values" {
+      assertUniqueDescs(NeetsVoiceIdType.entries) { it.desc }
+    }
+
+    "OpenAIModelType UNSPECIFIED has correct desc" {
+      OpenAIModelType.UNSPECIFIED.desc shouldBe UNSPECIFIED_DEFAULT
+    }
+
+    "OpenAIModelType isSpecified returns false for UNSPECIFIED" {
+      OpenAIModelType.UNSPECIFIED.isSpecified() shouldBe false
+    }
+
+    "OpenAIModelType isNotSpecified returns true for UNSPECIFIED" {
+      OpenAIModelType.UNSPECIFIED.isNotSpecified() shouldBe true
+    }
+
+    "OpenAIModelType isSpecified returns true for real entry" {
+      OpenAIModelType.GPT_4O.isSpecified() shouldBe true
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.github.pambrose.common.json.toJsonElement
+import com.vapi4k.api.tools.ToolCall
+import com.vapi4k.api.toolservice.ToolCallService
+import com.vapi4k.api.vapi4k.RequestContext
+import com.vapi4k.common.AssistantId.Companion.toAssistantId
+import com.vapi4k.common.SessionId.Companion.toSessionId
+import com.vapi4k.dsl.functions.FunctionDetails
+import com.vapi4k.dsl.functions.ToolCallInfo
+import com.vapi4k.dsl.vapi4k.InboundCallApplicationImpl
+import com.vapi4k.dtos.tools.CommonToolMessageDto
+import com.vapi4k.server.RequestContextImpl
+import com.vapi4k.utils.ReflectionUtils.toolCallFunction
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class FunctionDetailsTest : StringSpec() {
+  class StringService {
+    @ToolCall("Returns greeting")
+    fun greet(name: String): String = "Hello, $name!"
+  }
+
+  class UnitService {
+    @ToolCall("Does nothing")
+    fun doNothing() {}
+  }
+
+  class IntService {
+    @ToolCall("Adds numbers")
+    fun add(
+      a: Int,
+      b: Int,
+    ): Int = a + b
+  }
+
+  class ThrowingService {
+    @ToolCall("Always fails")
+    fun fail(): String = throw IllegalArgumentException("Intentional failure")
+  }
+
+  class ContextService {
+    @ToolCall("Uses request context")
+    fun withContext(
+      name: String,
+      requestContext: RequestContext,
+    ): String = "Hello $name from session ${requestContext.sessionId}"
+  }
+
+  class CompleteService : ToolCallService() {
+    @ToolCall("Weather lookup")
+    fun getWeather(city: String): String = "Sunny in $city"
+
+    override fun onToolCallComplete(
+      requestContext: RequestContext,
+      result: String,
+    ) = requestCompleteMessages {
+      requestCompleteMessage {
+        content = "Complete: $result"
+      }
+    }
+  }
+
+  class FailingToolCallService : ToolCallService() {
+    @ToolCall("Always fails")
+    fun fail(): String = throw RuntimeException("Service error")
+
+    override fun onToolCallFailed(
+      requestContext: RequestContext,
+      errorMessage: String,
+    ) = requestFailedMessages {
+      requestFailedMessage {
+        content = "Failed: $errorMessage"
+      }
+    }
+  }
+
+  private fun createRequestContext(): RequestContextImpl {
+    val app = InboundCallApplicationImpl()
+    return RequestContextImpl(
+      application = app,
+      request = """{"message":{"type":"tool-calls"}}""".toJsonElement(),
+      sessionId = "test-session".toSessionId(),
+      assistantId = "test-assistant".toAssistantId(),
+    )
+  }
+
+  private fun createFunctionDetails(obj: Any): FunctionDetails {
+    val function = obj.toolCallFunction
+    val toolCallInfo = ToolCallInfo("test-assistant".toAssistantId(), function)
+    return FunctionDetails(obj, function, toolCallInfo)
+  }
+
+  init {
+    "invokeToolMethod returns string result for String-returning ToolCall" {
+      val service = StringService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"name":"World"}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "Hello, World!"
+      details.invokeCount shouldBe 1
+    }
+
+    "invokeToolMethod returns empty string for Unit-returning ToolCall" {
+      val service = UnitService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{}""".toJsonElement()
+      var result = "not-set"
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe ""
+    }
+
+    "invokeToolMethod handles Int parameters and return type" {
+      val service = IntService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"a":3,"b":4}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "7"
+    }
+
+    "invokeToolMethod calls errorAction on exception" {
+      val service = ThrowingService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{}""".toJsonElement()
+      var errorResult = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = {},
+        errorAction = { errorResult = it },
+      )
+
+      errorResult shouldContain "Intentional failure"
+    }
+
+    "invokeToolMethod injects RequestContext when parameter is present" {
+      val service = ContextService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"name":"Alice"}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldContain "Hello Alice from session test-session"
+    }
+
+    "invokeToolMethod calls onToolCallComplete for ToolCallService on success" {
+      val service = CompleteService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"city":"Boston"}""".toJsonElement()
+      val messageDtos = mutableListOf<CommonToolMessageDto>()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        messageDtos = messageDtos,
+        successAction = { result = it },
+        errorAction = {},
+      )
+
+      result shouldBe "Sunny in Boston"
+      messageDtos.shouldNotBeEmpty()
+    }
+
+    "invokeToolMethod calls onToolCallFailed for ToolCallService on error" {
+      val service = FailingToolCallService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{}""".toJsonElement()
+      val messageDtos = mutableListOf<CommonToolMessageDto>()
+      var errorResult = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        messageDtos = messageDtos,
+        successAction = {},
+        errorAction = { errorResult = it },
+      )
+
+      errorResult shouldContain "Service error"
+      messageDtos.shouldNotBeEmpty()
+    }
+
+    "invokeCount increments on each invocation" {
+      val service = StringService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"name":"Test"}""".toJsonElement()
+
+      details.invokeCount shouldBe 0
+
+      details.invokeToolMethod(
+        isTool = false,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = {},
+        errorAction = {},
+      )
+      details.invokeCount shouldBe 1
+
+      details.invokeToolMethod(
+        isTool = false,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = {},
+        errorAction = {},
+      )
+      details.invokeCount shouldBe 2
+    }
+
+    "fqName includes class and function name" {
+      val service = StringService()
+      val details = createFunctionDetails(service)
+      details.fqName shouldContain "StringService"
+      details.fqName shouldContain "greet"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionInfoTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionInfoTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.common.AssistantId.Companion.toAssistantId
+import com.vapi4k.common.FunctionName.Companion.toFunctionName
+import com.vapi4k.common.SessionId.Companion.toSessionId
+import com.vapi4k.dsl.functions.FunctionInfo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+
+class FunctionInfoTest : StringSpec() {
+  init {
+    "containsFunction returns false for unknown name" {
+      val info = FunctionInfo("s1".toSessionId(), "a1".toAssistantId())
+      info.containsFunction("missing_a1".toFunctionName()) shouldBe false
+    }
+
+    "getFunction throws for unknown name" {
+      val info = FunctionInfo("s1".toSessionId(), "a1".toAssistantId())
+      shouldThrow<IllegalStateException> {
+        info.getFunction("missing_a1".toFunctionName())
+      }.message shouldBe "Function not found: \"missing_a1\""
+    }
+
+    "getFunctionOrNull returns null for unknown name" {
+      val info = FunctionInfo("s1".toSessionId(), "a1".toAssistantId())
+      info.getFunctionOrNull("missing_a1".toFunctionName()) shouldBe null
+    }
+
+    "size reflects number of added functions" {
+      val info = FunctionInfo("s1".toSessionId(), "a1".toAssistantId())
+      info.size shouldBe 0
+    }
+
+    "toFunctionInfoDto includes created and age" {
+      val info = FunctionInfo("s1".toSessionId(), "a1".toAssistantId())
+      val dto = info.toFunctionInfoDto()
+      dto.created.shouldNotBeEmpty()
+      dto.age.shouldNotBeEmpty()
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionUtilsTest.kt
@@ -22,13 +22,13 @@ import com.vapi4k.dsl.functions.FunctionUtils.llmType
 import com.vapi4k.dsl.functions.FunctionUtils.verifyIsToolCall
 import com.vapi4k.dsl.functions.FunctionUtils.verifyIsValidReturnType
 import com.vapi4k.dsl.functions.FunctionUtils.verifyObjectHasOnlyOneToolCall
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldContain
-import org.junit.jupiter.api.Assertions.assertThrows
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlin.reflect.KFunction
-import kotlin.test.Test
 
-class FunctionUtilsTest {
+class FunctionUtilsTest : StringSpec() {
   class NoAnnotationService {
     fun doSomething(): String = "hello"
   }
@@ -74,101 +74,79 @@ class FunctionUtilsTest {
   private inline fun <reified T : Any> T.memberFunction(name: String): KFunction<*> =
     this::class.members.first { it.name == name } as KFunction<*>
 
-  @Test
-  fun `verifyIsToolCall rejects unannotated function`() {
-    val function = NoAnnotationService().memberFunction("doSomething")
-    assertThrows(IllegalStateException::class.java) {
-      verifyIsToolCall(true, function)
-    }.also {
-      it.message.orEmpty() shouldContain "missing @ToolCall annotation"
+  init {
+    "verifyIsToolCall rejects unannotated function" {
+      val function = NoAnnotationService().memberFunction("doSomething")
+      shouldThrow<IllegalStateException> {
+        verifyIsToolCall(true, function)
+      }.message shouldContain "missing @ToolCall annotation"
     }
-  }
 
-  @Test
-  fun `verifyObjectHasOnlyOneToolCall rejects zero annotations`() {
-    assertThrows(IllegalStateException::class.java) {
-      verifyObjectHasOnlyOneToolCall(NoAnnotationService())
-    }.also {
-      it.message.orEmpty() shouldContain "No method with @ToolCall annotation found"
+    "verifyObjectHasOnlyOneToolCall rejects zero annotations" {
+      shouldThrow<IllegalStateException> {
+        verifyObjectHasOnlyOneToolCall(NoAnnotationService())
+      }.message shouldContain "No method with @ToolCall annotation found"
     }
-  }
 
-  @Test
-  fun `verifyObjectHasOnlyOneToolCall rejects two annotations`() {
-    assertThrows(IllegalStateException::class.java) {
-      verifyObjectHasOnlyOneToolCall(TwoAnnotationService())
-    }.also {
-      it.message.orEmpty() shouldContain "Only one method with @ToolCall annotation is allowed"
+    "verifyObjectHasOnlyOneToolCall rejects two annotations" {
+      shouldThrow<IllegalStateException> {
+        verifyObjectHasOnlyOneToolCall(TwoAnnotationService())
+      }.message shouldContain "Only one method with @ToolCall annotation is allowed"
     }
-  }
 
-  @Test
-  fun `verifyObjectHasOnlyOneToolCall accepts valid service`() {
-    verifyObjectHasOnlyOneToolCall(ValidService())
-  }
-
-  @Test
-  fun `verifyIsValidReturnType rejects List return`() {
-    val function = ListReturnService().memberFunction("getItems")
-    assertThrows(IllegalStateException::class.java) {
-      verifyIsValidReturnType(true, function)
-    }.also {
-      it.message.orEmpty() shouldContain "Allowed return types are String, Int, Double, Boolean or Unit"
+    "verifyObjectHasOnlyOneToolCall accepts valid service" {
+      verifyObjectHasOnlyOneToolCall(ValidService())
     }
-  }
 
-  @Test
-  fun `verifyIsValidReturnType accepts String return`() {
-    verifyIsValidReturnType(true, ValidService().memberFunction("doWork"))
-  }
+    "verifyIsValidReturnType rejects List return" {
+      val function = ListReturnService().memberFunction("getItems")
+      shouldThrow<IllegalStateException> {
+        verifyIsValidReturnType(true, function)
+      }.message shouldContain "Allowed return types are String, Int, Double, Boolean or Unit"
+    }
 
-  @Test
-  fun `verifyIsValidReturnType accepts Unit return`() {
-    verifyIsValidReturnType(true, UnitReturnService().memberFunction("doWork"))
-  }
+    "verifyIsValidReturnType accepts String return" {
+      verifyIsValidReturnType(true, ValidService().memberFunction("doWork"))
+    }
 
-  @Test
-  fun `verifyIsValidReturnType accepts Int return`() {
-    verifyIsValidReturnType(true, IntReturnService().memberFunction("getCount"))
-  }
+    "verifyIsValidReturnType accepts Unit return" {
+      verifyIsValidReturnType(true, UnitReturnService().memberFunction("doWork"))
+    }
 
-  @Test
-  fun `verifyIsValidReturnType accepts Boolean return`() {
-    verifyIsValidReturnType(true, BooleanReturnService().memberFunction("isReady"))
-  }
+    "verifyIsValidReturnType accepts Int return" {
+      verifyIsValidReturnType(true, IntReturnService().memberFunction("getCount"))
+    }
 
-  @Test
-  fun `verifyIsValidReturnType accepts Double return`() {
-    verifyIsValidReturnType(true, DoubleReturnService().memberFunction("getScore"))
-  }
+    "verifyIsValidReturnType accepts Boolean return" {
+      verifyIsValidReturnType(true, BooleanReturnService().memberFunction("isReady"))
+    }
 
-  @Test
-  fun `llmType mapping for String`() {
-    String::class.llmType shouldBeEqualTo "string"
-  }
+    "verifyIsValidReturnType accepts Double return" {
+      verifyIsValidReturnType(true, DoubleReturnService().memberFunction("getScore"))
+    }
 
-  @Test
-  fun `llmType mapping for Int`() {
-    Int::class.llmType shouldBeEqualTo "integer"
-  }
+    "llmType mapping for String" {
+      String::class.llmType shouldBe "string"
+    }
 
-  @Test
-  fun `llmType mapping for Double`() {
-    Double::class.llmType shouldBeEqualTo "double"
-  }
+    "llmType mapping for Int" {
+      Int::class.llmType shouldBe "integer"
+    }
 
-  @Test
-  fun `llmType mapping for Boolean`() {
-    Boolean::class.llmType shouldBeEqualTo "boolean"
-  }
+    "llmType mapping for Double" {
+      Double::class.llmType shouldBe "double"
+    }
 
-  @Test
-  fun `llmType mapping for unknown type`() {
-    Any::class.llmType shouldBeEqualTo "object"
-  }
+    "llmType mapping for Boolean" {
+      Boolean::class.llmType shouldBe "boolean"
+    }
 
-  @Test
-  fun `allowedParamTypes contains expected types`() {
-    FunctionUtils.allowedParamTypes shouldBeEqualTo setOf(String::class, Int::class, Double::class, Boolean::class)
+    "llmType mapping for unknown type" {
+      Any::class.llmType shouldBe "object"
+    }
+
+    "allowedParamTypes contains expected types" {
+      FunctionUtils.allowedParamTypes shouldBe setOf(String::class, Int::class, Double::class, Boolean::class)
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/JsonExtensionTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/JsonExtensionTest.kt
@@ -21,11 +21,11 @@ import com.github.pambrose.common.json.jsonElementList
 import com.github.pambrose.common.json.stringValue
 import com.github.pambrose.common.json.toJsonElement
 import com.vapi4k.utils.JsonUtils.toObjectList
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
-import org.amshove.kluent.shouldBeEqualTo
-import kotlin.test.Test
 
-class JsonExtensionTest {
+class JsonExtensionTest : StringSpec() {
   val json = """
     {
       "message": {
@@ -304,64 +304,58 @@ class JsonExtensionTest {
     }
   """.trimIndent()
 
-  @Test
-  fun testStringValue() {
-    val obj = json.toJsonElement()
-    obj["message"]["type"].stringValue shouldBeEqualTo "tool-calls"
-    obj.stringValue("message.type") shouldBeEqualTo "tool-calls"
-  }
+  init {
+    "testStringValue" {
+      val obj = json.toJsonElement()
+      obj["message"]["type"].stringValue shouldBe "tool-calls"
+      obj.stringValue("message.type") shouldBe "tool-calls"
+    }
 
-  @Test
-  fun testPathVarargs() {
-    val obj = json.toJsonElement()
-    obj["message", "type"].stringValue shouldBeEqualTo "tool-calls"
-    obj.stringValue("message.type") shouldBeEqualTo "tool-calls"
-  }
+    "testPathVarargs" {
+      val obj = json.toJsonElement()
+      obj["message", "type"].stringValue shouldBe "tool-calls"
+      obj.stringValue("message.type") shouldBe "tool-calls"
+    }
 
-  @Test
-  fun testPathString() {
-    val obj = json.toJsonElement()
-    obj.stringValue("message.type") shouldBeEqualTo "tool-calls"
-  }
+    "testPathString" {
+      val obj = json.toJsonElement()
+      obj.stringValue("message.type") shouldBe "tool-calls"
+    }
 
-  @Test
-  fun testArrayValues() {
-    val obj = json.toJsonElement()
-    obj.jsonElementList("message.toolWithToolCallList").size shouldBeEqualTo 1
-  }
+    "testArrayValues" {
+      val obj = json.toJsonElement()
+      obj.jsonElementList("message.toolWithToolCallList").size shouldBe 1
+    }
 
-  @Test
-  fun testOnceAgain() {
-    val str = """
-      {
-        "async": false,
-        "servers": [
-          {
-            "url": "https://myapp.ondigitalocean.app/toolCall1",
-            "secret": "12345"
-          },
-          {
-            "url": "https://myapp.ondigitalocean.app/toolCall2",
-            "secret": "12345"
-          },
-          {
-            "url": "https://myapp.ondigitalocean.app/toolCall3",
-            "secret": "12345"
-          }
-        ]
-      }
-    """.trimIndent()
+    "testOnceAgain" {
+      val str = """
+        {
+          "async": false,
+          "servers": [
+            {
+              "url": "https://myapp.ondigitalocean.app/toolCall1",
+              "secret": "12345"
+            },
+            {
+              "url": "https://myapp.ondigitalocean.app/toolCall2",
+              "secret": "12345"
+            },
+            {
+              "url": "https://myapp.ondigitalocean.app/toolCall3",
+              "secret": "12345"
+            }
+          ]
+        }
+      """.trimIndent()
 
-    @Serializable
-    class Server(
-      val url: String,
-      val secret: String,
-    )
+      @Serializable
+      class Server(
+        val url: String,
+        val secret: String,
+      )
 
-    val jsonElement = str.toJsonElement()
-    val servers = jsonElement["servers"].toObjectList<Server>()
-//    for (server in servers) {
-//      println(server.url)
-//    }
+      val jsonElement = str.toJsonElement()
+      val servers = jsonElement["servers"].toObjectList<Server>()
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ManualToolCacheTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ManualToolCacheTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.common.FunctionName.Companion.toFunctionName
+import com.vapi4k.dsl.tools.ManualToolCache
+import com.vapi4k.dsl.tools.ToolWithServerImpl
+import com.vapi4k.dtos.tools.ToolDto
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ManualToolCacheTest : StringSpec() {
+  init {
+    "addToCache stores tool and containsTool returns true" {
+      val cache = ManualToolCache { "/test" }
+      val toolName = "myTool_a1".toFunctionName()
+      cache.addToCache(toolName, ToolWithServerImpl("myTool", ToolDto()))
+      cache.containsTool(toolName) shouldBe true
+    }
+
+    "addToCache skips duplicate tool name silently" {
+      val cache = ManualToolCache { "/test" }
+      val toolName = "myTool_a1".toFunctionName()
+      val tool1 = ToolWithServerImpl("myTool", ToolDto())
+      val tool2 = ToolWithServerImpl("myTool-v2", ToolDto())
+      cache.addToCache(toolName, tool1)
+      cache.addToCache(toolName, tool2)
+      cache.getTool(toolName) shouldBe tool1
+    }
+
+    "containsTool returns false for unknown name" {
+      val cache = ManualToolCache { "/test" }
+      cache.containsTool("unknown_a1".toFunctionName()) shouldBe false
+    }
+
+    "getTool throws for unknown function name" {
+      val cache = ManualToolCache { "/test" }
+      shouldThrow<IllegalStateException> {
+        cache.getTool("unknown_a1".toFunctionName())
+      }.message shouldBe "Manual tool not found: unknown_a1"
+    }
+
+    "cacheAsJson reflects cache size" {
+      val cache = ManualToolCache { "/test" }
+      cache.cacheAsJson().cacheSize shouldBe 0
+      cache.addToCache("tool1_a1".toFunctionName(), ToolWithServerImpl("tool1", ToolDto()))
+      cache.cacheAsJson().cacheSize shouldBe 1
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.utils.MiscUtils.appendQueryParams
+import com.vapi4k.utils.MiscUtils.findFunction
+import com.vapi4k.utils.MiscUtils.removeEnds
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class MiscUtilsTest : StringSpec() {
+  class SampleClass {
+    fun myMethod(): String = "hello"
+
+    fun anotherMethod(): Int = 42
+  }
+
+  init {
+    "removeEnds strips matching prefix and suffix" {
+      "/path/".removeEnds("/") shouldBe "path"
+    }
+
+    "removeEnds with no matching ends" {
+      "path".removeEnds("/") shouldBe "path"
+    }
+
+    "removeEnds with default parameter" {
+      "/hello/".removeEnds() shouldBe "hello"
+    }
+
+    "removeEnds with same prefix and suffix character" {
+      "\"quoted\"".removeEnds("\"") shouldBe "quoted"
+    }
+
+    "appendQueryParams adds first parameter with question mark" {
+      val result = "http://example.com".appendQueryParams("key" to "value")
+      result shouldBe "http://example.com?key=value"
+    }
+
+    "appendQueryParams adds second parameter with ampersand" {
+      val result = "http://example.com?existing=1".appendQueryParams("key" to "value")
+      result shouldBe "http://example.com?existing=1&key=value"
+    }
+
+    "appendQueryParams handles multiple parameters" {
+      val result = "http://example.com".appendQueryParams("a" to "1", "b" to "2")
+      result shouldContain "a=1"
+      result shouldContain "b=2"
+      result.count { it == '?' } shouldBe 1
+    }
+
+    "appendQueryParams encodes parameter values" {
+      val result = "http://example.com".appendQueryParams("q" to "hello world")
+      result shouldContain "q=hello+world"
+    }
+
+    "findFunction returns matching function" {
+      val obj = SampleClass()
+      val func = obj.findFunction("myMethod")
+      func.name shouldBe "myMethod"
+    }
+
+    "findFunction throws for unknown method" {
+      val obj = SampleClass()
+      shouldThrow<IllegalStateException> {
+        obj.findFunction("nonExistent")
+      }.message shouldContain "not found"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ModelProviderTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ModelProviderTest.kt
@@ -25,124 +25,117 @@ import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.api.model.OpenAIModelType
 import com.vapi4k.dsl.vapi4k.Vapi4kConfigImpl
 import com.vapi4k.utils.assistantResponse
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class ModelProviderTest {
+class ModelProviderTest : StringSpec() {
   init {
     Vapi4kConfigImpl()
   }
 
-  @Test
-  fun `openAI model serializes provider and modelType`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+  init {
+    "openAI model serializes provider and modelType" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.model.provider") shouldBeEqualTo "openai"
-    je.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo "gpt-3.5-turbo"
-  }
-
-  @Test
-  fun `anthropic model serializes provider and modelType`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          anthropicModel {
-            modelType = AnthropicModelType.CLAUDE_3_5_SONNET_20241022
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.model.provider") shouldBeEqualTo "anthropic"
-    je.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo "claude-3-5-sonnet-20241022"
-  }
-
-  @Test
-  fun `groq model serializes provider and modelType`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_70B_8192
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.model.provider") shouldBeEqualTo "groq"
-    je.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo "llama3-70b-8192"
-  }
-
-  @Test
-  fun `customLLM model serializes provider and model`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          customLLMModel {
-            model = "my-model"
-            url = "https://my-llm.example.com/v1"
-            systemMessage = "You are a helpful assistant"
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.model.provider") shouldBeEqualTo "custom-llm"
-    je.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo "my-model"
-    je.stringValue("messageResponse.assistant.model.url") shouldBeEqualTo "https://my-llm.example.com/v1"
-  }
-
-  @Test
-  fun `openAI model with systemMessage`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            systemMessage = "You are a test assistant"
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    val messages = je.jsonElementList("messageResponse.assistant.model.messages")
-    messages.first().stringValue("content") shouldBeEqualTo "You are a test assistant"
-  }
-
-  @Test
-  fun `multiple model blocks throws error`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-          }
-          anthropicModel {
-            modelType = AnthropicModelType.CLAUDE_3_5_SONNET_20241022
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "openAIModel{} already called"
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.model.provider") shouldBe "openai"
+      je.stringValue("messageResponse.assistant.model.model") shouldBe "gpt-3.5-turbo"
     }
-  }
 
-  @Test
-  fun `anthropic model with customModel`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          anthropicModel {
-            customModel = "claude-custom-model"
+    "anthropic model serializes provider and modelType" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            anthropicModel {
+              modelType = AnthropicModelType.CLAUDE_3_5_SONNET_20241022
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.model.provider") shouldBeEqualTo "anthropic"
-    je.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo "claude-custom-model"
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.model.provider") shouldBe "anthropic"
+      je.stringValue("messageResponse.assistant.model.model") shouldBe "claude-3-5-sonnet-20241022"
+    }
+
+    "groq model serializes provider and modelType" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_70B_8192
+            }
+          }
+        }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.model.provider") shouldBe "groq"
+      je.stringValue("messageResponse.assistant.model.model") shouldBe "llama3-70b-8192"
+    }
+
+    "customLLM model serializes provider and model" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            customLLMModel {
+              model = "my-model"
+              url = "https://my-llm.example.com/v1"
+              systemMessage = "You are a helpful assistant"
+            }
+          }
+        }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.model.provider") shouldBe "custom-llm"
+      je.stringValue("messageResponse.assistant.model.model") shouldBe "my-model"
+      je.stringValue("messageResponse.assistant.model.url") shouldBe "https://my-llm.example.com/v1"
+    }
+
+    "openAI model with systemMessage" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              systemMessage = "You are a test assistant"
+            }
+          }
+        }
+      val je = response.toJsonElement()
+      val messages = je.jsonElementList("messageResponse.assistant.model.messages")
+      messages.first().stringValue("content") shouldBe "You are a test assistant"
+    }
+
+    "multiple model blocks throws error" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+            }
+            anthropicModel {
+              modelType = AnthropicModelType.CLAUDE_3_5_SONNET_20241022
+            }
+          }
+        }
+      }.message shouldBe "openAIModel{} already called"
+    }
+
+    "anthropic model with customModel" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            anthropicModel {
+              customModel = "claude-custom-model"
+            }
+          }
+        }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.model.provider") shouldBe "anthropic"
+      je.stringValue("messageResponse.assistant.model.model") shouldBe "claude-custom-model"
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ModelTests.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ModelTests.kt
@@ -25,334 +25,312 @@ import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.OpenAIModelType
 import com.vapi4k.utils.assistantResponse
 import com.vapi4k.utils.tools
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
-class ModelTests {
-  @Test
-  fun `tool server details`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-            tools {
-              dtmfTool {
-                async = false
-                onInvoke { }
-                server {
-                  url = "zzz"
-                  secret = "123"
-                  timeoutSeconds = 10
+class ModelTests : StringSpec() {
+  init {
+    "tool server details" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+              tools {
+                dtmfTool {
+                  async = false
+                  onInvoke { }
+                  server {
+                    url = "zzz"
+                    secret = "123"
+                    timeoutSeconds = 10
+                  }
                 }
               }
             }
           }
         }
-      }
 
-    val je = response.toJsonElement()
-    val server = je.tools().first()["server"]
-    server.stringValue("url") shouldBeEqualTo "zzz"
-    server.stringValue("secret") shouldBeEqualTo "123"
-    server.stringValue("timeoutSeconds") shouldBeEqualTo "10"
-    je.tools().first().booleanValue("async").shouldBeFalse()
-  }
-
-  @Test
-  fun `missing external tool name blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-
-            tools {
-              externalTool {
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "externalTool{} parameter name is required"
+      val je = response.toJsonElement()
+      val server = je.tools().first()["server"]
+      server.stringValue("url") shouldBe "zzz"
+      server.stringValue("secret") shouldBe "123"
+      server.stringValue("timeoutSeconds") shouldBe "10"
+      je.tools().first().booleanValue("async") shouldBe false
     }
-  }
 
-  @Test
-  fun `blank external tool name blocks`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "missing external tool name blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = ""
-
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
+              tools {
+                externalTool {
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
                 }
               }
             }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "externalTool{} parameter name is required"
+      }.message shouldBe "externalTool{} parameter name is required"
     }
-  }
 
-  @Test
-  fun `Check description with external tool decl`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "blank external tool name blocks" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = "wed"
-                description = "a description"
-                async = true
+              tools {
+                externalTool {
+                  name = ""
+
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "externalTool{} parameter name is required"
+    }
+
+    "Check description with external tool decl" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+
+              tools {
+                externalTool {
+                  name = "wed"
+                  description = "a description"
+                  async = true
 //                onInvoke { args ->
 //
 //                }
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
-                }
-              }
-            }
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    val tool = je.tools().first()
-    tool["function"].stringValue("name") shouldBeEqualTo "wed"
-    tool["function"].stringValue("description") shouldBeEqualTo "a description"
-    tool.stringValue("async") shouldBeEqualTo "true"
-  }
-
-  @Test
-  fun `blank param names with external tool decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-
-            tools {
-              externalTool {
-                name = "wed"
-                description = "a description"
-                async = true
-
-                parameters {
-                  parameter {
-                    name = ""
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
                   }
                 }
-
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
-                }
               }
             }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "Parameter name must be assigned in externalTool{}"
+      val je = response.toJsonElement()
+      val tool = je.tools().first()
+      tool["function"].stringValue("name") shouldBe "wed"
+      tool["function"].stringValue("description") shouldBe "a description"
+      tool.stringValue("async") shouldBe "true"
     }
-  }
 
-  @Test
-  fun `Bad type with external tool decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "blank param names with external tool decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = "wed"
-                description = "a description"
-                async = true
+              tools {
+                externalTool {
+                  name = "wed"
+                  description = "a description"
+                  async = true
 
-                parameters {
-                  parameter {
-                    name = "param1"
-                    description = "a description"
-                    type = Any::class
+                  parameters {
+                    parameter {
+                      name = ""
+                    }
                   }
-                }
 
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
                 }
               }
             }
           }
         }
-      }
-    }.also {
-      assert(it.message.orEmpty().contains("externalTool{} parameter type must be one of"))
+      }.message shouldBe "Parameter name must be assigned in externalTool{}"
     }
-  }
 
-  @Test
-  fun `Duplicate param names external tool decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "Bad type with external tool decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = "wed"
-                description = "a description"
-                async = true
+              tools {
+                externalTool {
+                  name = "wed"
+                  description = "a description"
+                  async = true
 
-                parameters {
-                  parameter {
-                    name = "param1"
-                    description = "a description"
+                  parameters {
+                    parameter {
+                      name = "param1"
+                      description = "a description"
+                      type = Any::class
+                    }
                   }
-                  parameter {
-                    name = "param1"
-                    description = "a description"
-                  }
-                }
 
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
                 }
               }
             }
           }
         }
-      }
-    }.also {
-      assert(it.message.orEmpty().contains("already exists"))
+      }.message shouldContain "externalTool{} parameter type must be one of"
     }
-  }
 
-  @Test
-  fun `check parameters with external tool decl`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "Duplicate param names external tool decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = "wed"
-                description = "a description"
-                async = true
+              tools {
+                externalTool {
+                  name = "wed"
+                  description = "a description"
+                  async = true
 
-                parameters {
-                  parameter {
-                    name = "param1"
-                    description = "a description"
+                  parameters {
+                    parameter {
+                      name = "param1"
+                      description = "a description"
+                    }
+                    parameter {
+                      name = "param1"
+                      description = "a description"
+                    }
                   }
-                  parameter {
-                    name = "param2"
-                    description = "a description"
-                  }
-                  parameter {
-                    name = "param3"
-                    description = "a description"
-                    type = Int::class
-                  }
-                }
 
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
                 }
               }
             }
           }
         }
-      }
-    val je = response.toJsonElement()
-    val tool = je.tools().first()
-    tool["function.parameters.properties"].keys.size shouldBeEqualTo 3
-  }
-
-  @Test
-  fun `multiple server with external tool decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
-
-            tools {
-              externalTool {
-                name = "wed"
-
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
-                }
-                server {
-                  url = "yyy"
-                  secret = "456"
-                  timeoutSeconds = 5
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "externalTool{} contains multiple calls to server{}"
+      }.message shouldContain "already exists"
     }
-  }
 
-  @Test
-  fun `missing server with external tool decl`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          openAIModel {
-            modelType = OpenAIModelType.GPT_3_5_TURBO
+    "check parameters with external tool decl" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
 
-            tools {
-              externalTool {
-                name = "wed"
+              tools {
+                externalTool {
+                  name = "wed"
+                  description = "a description"
+                  async = true
+
+                  parameters {
+                    parameter {
+                      name = "param1"
+                      description = "a description"
+                    }
+                    parameter {
+                      name = "param2"
+                      description = "a description"
+                    }
+                    parameter {
+                      name = "param3"
+                      description = "a description"
+                      type = Int::class
+                    }
+                  }
+
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
+                }
               }
             }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "externalTool{} must contain a call to server{}"
+      val je = response.toJsonElement()
+      val tool = je.tools().first()
+      tool["function.parameters.properties"].keys.size shouldBe 3
+    }
+
+    "multiple server with external tool decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+
+              tools {
+                externalTool {
+                  name = "wed"
+
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
+                  server {
+                    url = "yyy"
+                    secret = "456"
+                    timeoutSeconds = 5
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "externalTool{} contains multiple calls to server{}"
+    }
+
+    "missing server with external tool decl" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            openAIModel {
+              modelType = OpenAIModelType.GPT_3_5_TURBO
+
+              tools {
+                externalTool {
+                  name = "wed"
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "externalTool{} must contain a call to server{}"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ReflectionUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ReflectionUtilsTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.api.tools.ToolCall
+import com.vapi4k.api.vapi4k.RequestContext
+import com.vapi4k.utils.ReflectionUtils.hasToolCallAnnotation
+import com.vapi4k.utils.ReflectionUtils.isUnitReturnType
+import com.vapi4k.utils.ReflectionUtils.parameterSignature
+import com.vapi4k.utils.ReflectionUtils.toolCallAnnotation
+import com.vapi4k.utils.ReflectionUtils.toolCallFunction
+import com.vapi4k.utils.ReflectionUtils.valueParameters
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.reflect.KFunction
+
+class ReflectionUtilsTest : StringSpec() {
+  class MultiMethodService {
+    fun regularMethod(): String = "hello"
+
+    @ToolCall("Annotated method")
+    fun annotatedMethod(name: String): String = name
+
+    fun anotherRegularMethod(): Int = 42
+  }
+
+  class UnitMethodService {
+    @ToolCall("Unit method")
+    fun doWork() {}
+  }
+
+  class ContextParamService {
+    @ToolCall("With context")
+    fun withContext(
+      name: String,
+      requestContext: RequestContext,
+    ): String = name
+  }
+
+  private inline fun <reified T : Any> T.memberFunction(name: String): KFunction<*> =
+    this::class.members.first { it.name == name } as KFunction<*>
+
+  init {
+    "toolCallFunction finds first ToolCall annotated method" {
+      val service = MultiMethodService()
+      val func = service.toolCallFunction
+      func.name shouldBe "annotatedMethod"
+    }
+
+    "valueParameters returns only non-instance parameters" {
+      val service = MultiMethodService()
+      val func = service.memberFunction("annotatedMethod")
+      val params = func.valueParameters
+      params.size shouldBe 1
+      params.first().first shouldBe "name"
+    }
+
+    "valueParameters includes RequestContext in parameter set" {
+      val service = ContextParamService()
+      val func = service.memberFunction("withContext")
+      val params = func.valueParameters
+      params.size shouldBe 2
+      params.map { it.first } shouldBe listOf("name", "requestContext")
+    }
+
+    "isUnitReturnType returns true for Unit-returning function" {
+      val func = UnitMethodService().memberFunction("doWork")
+      func.isUnitReturnType shouldBe true
+    }
+
+    "isUnitReturnType returns false for String-returning function" {
+      val func = MultiMethodService().memberFunction("annotatedMethod")
+      func.isUnitReturnType shouldBe false
+    }
+
+    "hasToolCallAnnotation returns true for annotated function" {
+      val func = MultiMethodService().memberFunction("annotatedMethod")
+      func.hasToolCallAnnotation shouldBe true
+    }
+
+    "hasToolCallAnnotation returns false for unannotated function" {
+      val func = MultiMethodService().memberFunction("regularMethod")
+      func.hasToolCallAnnotation shouldBe false
+    }
+
+    "toolCallAnnotation returns annotation for annotated function" {
+      val func = MultiMethodService().memberFunction("annotatedMethod")
+      val annotation = func.toolCallAnnotation
+      annotation?.description shouldBe "Annotated method"
+    }
+
+    "parameterSignature formats correctly" {
+      val func = MultiMethodService().memberFunction("annotatedMethod")
+      func.parameterSignature shouldBe "name: String"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ResponseTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ResponseTest.kt
@@ -22,44 +22,45 @@ import com.vapi4k.api.model.AnthropicModelType
 import com.vapi4k.api.transcriber.DeepgramModelType
 import com.vapi4k.dtos.api.destination.SipDestinationDto
 import com.vapi4k.utils.assistantResponse
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
 
-class ResponseTest {
-  @Test
-  fun testGetTwoSquadIds() {
-    val requestContext = newRequestContext()
-    val assistant =
-      assistantResponse(requestContext) {
-        assistant {
-          anthropicModel {
-            modelType = AnthropicModelType.CLAUDE_3_OPUS_20240229
+class ResponseTest : StringSpec() {
+  init {
+    "testGetTwoSquadIds" {
+      val requestContext = newRequestContext()
+      val assistant =
+        assistantResponse(requestContext) {
+          assistant {
+            anthropicModel {
+              modelType = AnthropicModelType.CLAUDE_3_OPUS_20240229
 //          maxTokens = 99
-            userMessage = "Hello"
-            userMessage += " Hello2"
-            systemMessage = "Hello4"
-            systemMessage += " Hello5"
+              userMessage = "Hello"
+              userMessage += " Hello2"
+              systemMessage = "Hello4"
+              systemMessage += " Hello5"
 
-            knowledgeBase {
-              fileIds += listOf("eeeee", "ffff")
-              topK = 5.3
+              knowledgeBase {
+                fileIds += listOf("eeeee", "ffff")
+                topK = 5.3
+              }
+            }
+
+            deepgramTranscriber {
+              transcriberModel = DeepgramModelType.BASE
+              customLanguage = "zzz"
             }
           }
+        }
 
-          deepgramTranscriber {
-            transcriberModel = DeepgramModelType.BASE
-            customLanguage = "zzz"
+      val dest =
+        assistantResponse(requestContext) {
+          sipDestination {
+            sipUri = "sip:wedwedwed"
+            message = "Hello"
           }
         }
-      }
 
-    val dest =
-      assistantResponse(requestContext) {
-        sipDestination {
-          sipUri = "sip:wedwedwed"
-          message = "Hello"
-        }
-      }
-
-    println((dest.messageResponse.destination as SipDestinationDto).toJsonString())
+      println((dest.messageResponse.destination as SipDestinationDto).toJsonString())
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.api.model.GroqModelType
+import com.vapi4k.common.CoreEnvVars.defaultServerPath
+import com.vapi4k.common.QueryParams.SECRET_PARAM
+import com.vapi4k.common.Utils.resourceFile
+import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
+import com.vapi4k.plugin.Vapi4k
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType.Application
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+
+class ServerRoutingTest : StringSpec() {
+  init {
+    "inboundCallRequest returns 403 when server secret is invalid" {
+      testApplication {
+        application {
+          install(Vapi4k) {
+            inboundCallApplication {
+              serverSecret = "correct-secret"
+              onAssistantRequest {
+                assistant {
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_70B_8192
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        val response =
+          client.post("/${INBOUND_CALL.pathPrefix}/$defaultServerPath?$SECRET_PARAM=wrong-secret") {
+            contentType(Application.Json)
+            setBody(resourceFile("/json-tool-tests/assistantRequest.json"))
+          }
+
+        response.status shouldBe HttpStatusCode.Forbidden
+      }
+    }
+
+    "inboundCallRequest returns SimpleMessageResponse for STATUS_UPDATE" {
+      testApplication {
+        application {
+          install(Vapi4k) {
+            inboundCallApplication {
+              onAssistantRequest {
+                assistant {
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_70B_8192
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        val statusUpdateJson = """
+          {
+            "message": {
+              "type": "status-update",
+              "status": "in-progress",
+              "call": {
+                "id": "call-123"
+              }
+            }
+          }
+        """.trimIndent()
+
+        val response =
+          client.post("/${INBOUND_CALL.pathPrefix}/$defaultServerPath") {
+            contentType(Application.Json)
+            setBody(statusUpdateJson)
+          }
+
+        response.status shouldBe HttpStatusCode.OK
+      }
+    }
+
+    "inboundCallRequest returns SimpleMessageResponse for TRANSCRIPT" {
+      testApplication {
+        application {
+          install(Vapi4k) {
+            inboundCallApplication {
+              onAssistantRequest {
+                assistant {
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_70B_8192
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        val transcriptJson = """
+          {
+            "message": {
+              "type": "transcript",
+              "transcript": "Hello, how are you?"
+            }
+          }
+        """.trimIndent()
+
+        val response =
+          client.post("/${INBOUND_CALL.pathPrefix}/$defaultServerPath") {
+            contentType(Application.Json)
+            setBody(transcriptJson)
+          }
+
+        response.status shouldBe HttpStatusCode.OK
+      }
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ServerTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ServerTest.kt
@@ -31,6 +31,8 @@ import com.vapi4k.plugin.Vapi4k
 import com.vapi4k.utils.JsonFilenames
 import com.vapi4k.utils.JsonUtils.firstInList
 import com.vapi4k.utils.withTestApplication
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -39,102 +41,98 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.application.install
 import io.ktor.server.testing.testApplication
-import org.amshove.kluent.shouldBeEqualTo
-import kotlin.test.Test
 
-class ServerTest {
+class ServerTest : StringSpec() {
   companion object {
     fun HttpRequestBuilder.configPost() {
       contentType(Application.Json)
     }
   }
 
-  @Test
-  fun `ping request`() {
-    testApplication {
-      application {
-        install(Vapi4k)
+  init {
+    "ping request" {
+      testApplication {
+        application {
+          install(Vapi4k)
+        }
+        val response = client.get("/ping")
+        response.status shouldBe HttpStatusCode.OK
+        response.bodyAsText() shouldBe "pong"
       }
-      val response = client.get("/ping")
-      response.status shouldBeEqualTo HttpStatusCode.OK
-      response.bodyAsText() shouldBeEqualTo "pong"
     }
-  }
 
-  @Test
-  fun `simple assistant request`() {
-    val (response, jsonElement) =
-      withTestApplication(INBOUND_CALL, JsonFilenames.JSON_ASSISTANT_REQUEST) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_70B_8192
+    "simple assistant request" {
+      val (response, jsonElement) =
+        withTestApplication(INBOUND_CALL, JsonFilenames.JSON_ASSISTANT_REQUEST) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_70B_8192
+            }
           }
         }
-      }
 
-    response.status shouldBeEqualTo HttpStatusCode.OK
-    jsonElement.stringValue("messageResponse.assistant.model.model") shouldBeEqualTo GroqModelType.LLAMA3_70B_8192.desc
-  }
-
-  // @Test
-  fun `Tool requests arg ordering`() {
-    val responses =
-      withTestApplication(
-        INBOUND_CALL,
-        listOf(
-          JsonFilenames.JSON_ASSISTANT_REQUEST,
-          "/json-tool-tests/toolRequest1.json",
-          "/json-tool-tests/toolRequest2.json",
-          "/json-tool-tests/toolRequest3.json",
-          "/json-tool-tests/toolRequest4.json",
-          "/json-tool-tests/endOfCallReportRequest.json",
-        ),
-        CACHES_PATH,
-        true,
-      ) {
-        doubleToolAssistant()
-      }
-
-    responses.forEachIndexed { i, (response, jsonElement) ->
-      response.status shouldBeEqualTo HttpStatusCode.OK
-      if (i in listOf(1, 2))
-        jsonElement["messageResponse.results"].firstInList()
-          .stringValue("result") shouldBeEqualTo "The weather in Danville, California is windy"
-
-      if (i in listOf(3, 4))
-        jsonElement["messageResponse.results"].firstInList()
-          .stringValue("result") shouldBeEqualTo "The weather in Boston, Massachusetts is rainy"
-
-      if (i == 6) {
-        val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
-        println(jsonElement.toJsonString())
-        jsonElement.intValue("$path.serviceTools.cacheSize") shouldBeEqualTo 0
-        jsonElement.intValue("$path.functions.cacheSize") shouldBeEqualTo 0
-      }
+      response.status shouldBe HttpStatusCode.OK
+      jsonElement.stringValue("messageResponse.assistant.model.model") shouldBe GroqModelType.LLAMA3_70B_8192.desc
     }
-  }
 
-  @Test
-  fun `Check for EOCR cache removal`() {
-    val responses =
-      withTestApplication(
-        INBOUND_CALL,
-        listOf(
-          JsonFilenames.JSON_ASSISTANT_REQUEST,
-          "/json-tool-tests/endOfCallReportRequest.json",
-        ),
-        CACHES_PATH,
-        false,
-      ) {
-        doubleToolAssistant()
-      }
-    responses.forEachIndexed { i, (response, jsonElement) ->
-      response.status shouldBeEqualTo HttpStatusCode.OK
-      if (i == 2) {
-        println(jsonElement.toJsonString())
-        val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
-        jsonElement["$path.functions.cache"].keys.size shouldBeEqualTo 0
-        jsonElement["$path.serviceTools.cache"].keys.size shouldBeEqualTo 2
+    // "Tool requests arg ordering" {
+    //   val responses =
+    //     withTestApplication(
+    //       INBOUND_CALL,
+    //       listOf(
+    //         JsonFilenames.JSON_ASSISTANT_REQUEST,
+    //         "/json-tool-tests/toolRequest1.json",
+    //         "/json-tool-tests/toolRequest2.json",
+    //         "/json-tool-tests/toolRequest3.json",
+    //         "/json-tool-tests/toolRequest4.json",
+    //         "/json-tool-tests/endOfCallReportRequest.json",
+    //       ),
+    //       CACHES_PATH,
+    //       true,
+    //     ) {
+    //       doubleToolAssistant()
+    //     }
+    //
+    //   responses.forEachIndexed { i, (response, jsonElement) ->
+    //     response.status shouldBe HttpStatusCode.OK
+    //     if (i in listOf(1, 2))
+    //       jsonElement["messageResponse.results"].firstInList()
+    //         .stringValue("result") shouldBe "The weather in Danville, California is windy"
+    //
+    //     if (i in listOf(3, 4))
+    //       jsonElement["messageResponse.results"].firstInList()
+    //         .stringValue("result") shouldBe "The weather in Boston, Massachusetts is rainy"
+    //
+    //     if (i == 6) {
+    //       val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
+    //       println(jsonElement.toJsonString())
+    //       jsonElement.intValue("$path.serviceTools.cacheSize") shouldBe 0
+    //       jsonElement.intValue("$path.functions.cacheSize") shouldBe 0
+    //     }
+    //   }
+    // }
+
+    "Check for EOCR cache removal" {
+      val responses =
+        withTestApplication(
+          INBOUND_CALL,
+          listOf(
+            JsonFilenames.JSON_ASSISTANT_REQUEST,
+            "/json-tool-tests/endOfCallReportRequest.json",
+          ),
+          CACHES_PATH,
+          false,
+        ) {
+          doubleToolAssistant()
+        }
+      responses.forEachIndexed { i, (response, jsonElement) ->
+        response.status shouldBe HttpStatusCode.OK
+        if (i == 2) {
+          println(jsonElement.toJsonString())
+          val path = "${INBOUND_CALL.pathPrefix.ensureStartsWith("/")}/$defaultServerPath"
+          jsonElement["$path.functions.cache"].keys.size shouldBe 0
+          jsonElement["$path.serviceTools.cache"].keys.size shouldBe 2
+        }
       }
     }
   }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/StringTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/StringTest.kt
@@ -17,136 +17,130 @@
 package com.vapi4k
 
 import com.vapi4k.api.prompt.Prompt.Companion.prompt
-import org.amshove.kluent.shouldBeEqualTo
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class StringTest {
-  @Test
-  fun `unaryPlus single test`() {
-    val str =
-      prompt {
-        +"test text"
-      }
+class StringTest : StringSpec() {
+  init {
+    "unaryPlus single test" {
+      val str =
+        prompt {
+          +"test text"
+        }
 
-    "test text" shouldBeEqualTo str
-  }
+      "test text" shouldBe str
+    }
 
-  @Test
-  fun `unaryPlus multi2a test`() {
-    val str =
-      prompt {
-        +"test text"
-        +"test text"
-      }
+    "unaryPlus multi2a test" {
+      val str =
+        prompt {
+          +"test text"
+          +"test text"
+        }
 
-    val goal =
-      """test text
+      val goal =
+        """test text
 
 test text"""
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `unaryPlus multi2b test`() {
-    val str =
-      prompt {
-        +"""test
+    "unaryPlus multi2b test" {
+      val str =
+        prompt {
+          +"""test
 text"""
-        +"""test
+          +"""test
 text"""
-      }
+        }
 
-    val goal =
-      """test
+      val goal =
+        """test
 text
 
 test
 text"""
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `unaryPlus multi3 test`() {
-    val str =
-      prompt {
-        +"test text"
-        +"test text"
-        +"test text"
-      }
+    "unaryPlus multi3 test" {
+      val str =
+        prompt {
+          +"test text"
+          +"test text"
+          +"test text"
+        }
 
-    val goal =
-      """test text
+      val goal =
+        """test text
 
 test text
 
 test text"""
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `singleLine no cr test`() {
-    val str =
-      prompt {
-        singleLine(
-          """Hello
+    "singleLine no cr test" {
+      val str =
+        prompt {
+          singleLine(
+            """Hello
          team
          later
       """,
-        )
-      }
+          )
+        }
 
-    val goal = "Hello team later"
+      val goal = "Hello team later"
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `singleLine single with cr test`() {
-    val str =
-      prompt {
-        singleLine(
-          """Welcome
+    "singleLine single with cr test" {
+      val str =
+        prompt {
+          singleLine(
+            """Welcome
             everyone
 
          team
          later
       """,
-        )
-      }
+          )
+        }
 
-    val goal = """Welcome everyone
+      val goal = """Welcome everyone
 
 team later"""
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `singleLine multi with cr test`() {
-    val str =
-      prompt {
-        singleLine(
-          """Welcome
+    "singleLine multi with cr test" {
+      val str =
+        prompt {
+          singleLine(
+            """Welcome
             everyone
 
          team
          later
       """,
-        )
+          )
 
-        singleLine(
-          """Welcome
+          singleLine(
+            """Welcome
             everyone
 
          team
          later
       """,
-        )
-      }
+          )
+        }
 
-    val goal = """Welcome everyone
+      val goal = """Welcome everyone
 
 team later
 
@@ -154,30 +148,29 @@ Welcome everyone
 
 team later"""
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `singleLine varargs multi with cr test`() {
-    val str =
-      prompt {
-        singleLine(
-          """Welcome
+    "singleLine varargs multi with cr test" {
+      val str =
+        prompt {
+          singleLine(
+            """Welcome
             everyone
 
          team
          later
       """,
-          """Welcome
+            """Welcome
             everyone
 
          team
          later
       """,
-        )
-      }
+          )
+        }
 
-    val goal = """Welcome everyone
+      val goal = """Welcome everyone
 
 team later
 
@@ -185,81 +178,78 @@ Welcome everyone
 
 team later"""
 
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `trimPrefix single line test`() {
-    val str =
-      prompt {
-        trimPrefix("    test text")
-      }
+    "trimPrefix single line test" {
+      val str =
+        prompt {
+          trimPrefix("    test text")
+        }
 
-    "test text" shouldBeEqualTo str
-  }
+      "test text" shouldBe str
+    }
 
-  @Test
-  fun `trimPrefix single multi line test`() {
-    val str =
-      prompt {
-        trimPrefix(
-          """Welcome
+    "trimPrefix single multi line test" {
+      val str =
+        prompt {
+          trimPrefix(
+            """Welcome
          team
          later""",
-        )
-      }
-    val goal = """Welcome
+          )
+        }
+      val goal = """Welcome
 team
 later"""
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `trimPrefix multi multi line test`() {
-    val str =
-      prompt {
-        trimPrefix(
-          """Welcome
+    "trimPrefix multi multi line test" {
+      val str =
+        prompt {
+          trimPrefix(
+            """Welcome
          team
          later""",
-        )
+          )
 
-        trimPrefix(
-          """Welcome
+          trimPrefix(
+            """Welcome
          team
          later""",
-        )
-      }
-    val goal = """Welcome
+          )
+        }
+      val goal = """Welcome
 team
 later
 
 Welcome
 team
 later"""
-    goal shouldBeEqualTo str
-  }
+      goal shouldBe str
+    }
 
-  @Test
-  fun `trimPrefix varargs multi line test`() {
-    val str =
-      prompt {
-        trimPrefix(
-          """Welcome
+    "trimPrefix varargs multi line test" {
+      val str =
+        prompt {
+          trimPrefix(
+            """Welcome
          team
          later""",
-          """Welcome
+            """Welcome
          team
          later""",
-        )
-      }
-    val goal = """Welcome
+          )
+        }
+      val goal = """Welcome
 team
 later
 
 Welcome
 team
 later"""
-    goal shouldBeEqualTo str
+      goal shouldBe str
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/TransferDestinationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/TransferDestinationTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.github.pambrose.common.json.toJsonElement
+import com.vapi4k.common.AssistantId.Companion.toAssistantId
+import com.vapi4k.common.SessionId.Companion.toSessionId
+import com.vapi4k.dsl.vapi4k.InboundCallApplicationImpl
+import com.vapi4k.server.RequestContextImpl
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+
+class TransferDestinationTest : StringSpec() {
+  private fun createRequestContext(app: InboundCallApplicationImpl): RequestContextImpl =
+    RequestContextImpl(
+      application = app,
+      request = """{"message":{"type":"transfer-destination-request"}}""".toJsonElement(),
+      sessionId = "test-session".toSessionId(),
+      assistantId = "test-assistant".toAssistantId(),
+    )
+
+  init {
+    "getTransferDestinationResponse errors when no handler assigned" {
+      val app = InboundCallApplicationImpl()
+      val requestContext = createRequestContext(app)
+      shouldThrow<IllegalStateException> {
+        app.getTransferDestinationResponse(requestContext)
+      }.message shouldContain "onTransferDestinationRequest{} not called"
+    }
+
+    "onTransferDestinationRequest errors on duplicate assignment" {
+      val app = InboundCallApplicationImpl()
+      app.onTransferDestinationRequest { }
+      shouldThrow<IllegalStateException> {
+        app.onTransferDestinationRequest { }
+      }.message shouldContain "onTransferDestinationRequest{} can be called only once"
+    }
+
+    "getTransferDestinationResponse errors when no destination set in handler" {
+      val app = InboundCallApplicationImpl()
+      app.onTransferDestinationRequest {
+        // Deliberately not calling numberDestination{}, sipDestination{}, or assistantDestination{}
+      }
+      val requestContext = createRequestContext(app)
+      shouldThrow<IllegalStateException> {
+        app.getTransferDestinationResponse(requestContext)
+      }.message shouldContain "missing a call to numberDestination{}"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ValueClassTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ValueClassTest.kt
@@ -21,62 +21,56 @@ import com.vapi4k.common.AssistantId.Companion.toAssistantId
 import com.vapi4k.common.CacheKey.Companion.cacheKeyValue
 import com.vapi4k.common.SessionId.Companion.EMPTY_SESSION_ID
 import com.vapi4k.common.SessionId.Companion.toSessionId
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeTrue
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
-class ValueClassTest {
-  @Test
-  fun `CacheKey composition from sessionId and assistantId`() {
-    val sessionId = "session123".toSessionId()
-    val assistantId = "assistant456".toAssistantId()
-    val cacheKey = cacheKeyValue(sessionId, assistantId)
-    cacheKey.value shouldBeEqualTo "session123_assistant456"
-  }
+class ValueClassTest : StringSpec() {
+  init {
+    "CacheKey composition from sessionId and assistantId" {
+      val sessionId = "session123".toSessionId()
+      val assistantId = "assistant456".toAssistantId()
+      val cacheKey = cacheKeyValue(sessionId, assistantId)
+      cacheKey.value shouldBe "session123_assistant456"
+    }
 
-  @Test
-  fun `CacheKey equality for same session and assistant`() {
-    val sessionId = "sess1".toSessionId()
-    val assistantId = "asst1".toAssistantId()
-    val key1 = cacheKeyValue(sessionId, assistantId)
-    val key2 = cacheKeyValue(sessionId, assistantId)
-    key1 shouldBeEqualTo key2
-  }
+    "CacheKey equality for same session and assistant" {
+      val sessionId = "sess1".toSessionId()
+      val assistantId = "asst1".toAssistantId()
+      val key1 = cacheKeyValue(sessionId, assistantId)
+      val key2 = cacheKeyValue(sessionId, assistantId)
+      key1 shouldBe key2
+    }
 
-  @Test
-  fun `CacheKey differs for different sessions`() {
-    val assistantId = "asst1".toAssistantId()
-    val key1 = cacheKeyValue("sess1".toSessionId(), assistantId)
-    val key2 = cacheKeyValue("sess2".toSessionId(), assistantId)
-    (key1 != key2).shouldBeTrue()
-  }
+    "CacheKey differs for different sessions" {
+      val assistantId = "asst1".toAssistantId()
+      val key1 = cacheKeyValue("sess1".toSessionId(), assistantId)
+      val key2 = cacheKeyValue("sess2".toSessionId(), assistantId)
+      key1 shouldNotBe key2
+    }
 
-  @Test
-  fun `AssistantId getAssistantIdFromSuffix extracts correctly`() {
-    val result = "functionName_assistantXYZ".getAssistantIdFromSuffix()
-    result.value shouldBeEqualTo "assistantXYZ"
-  }
+    "AssistantId getAssistantIdFromSuffix extracts correctly" {
+      val result = "functionName_assistantXYZ".getAssistantIdFromSuffix()
+      result.value shouldBe "assistantXYZ"
+    }
 
-  @Test
-  fun `AssistantId getAssistantIdFromSuffix with multiple separators`() {
-    val result = "some_function_name_asst123".getAssistantIdFromSuffix()
-    result.value shouldBeEqualTo "asst123"
-  }
+    "AssistantId getAssistantIdFromSuffix with multiple separators" {
+      val result = "some_function_name_asst123".getAssistantIdFromSuffix()
+      result.value shouldBe "asst123"
+    }
 
-  @Test
-  fun `SessionId toString returns value`() {
-    val sessionId = "my-session".toSessionId()
-    sessionId.toString() shouldBeEqualTo "my-session"
-  }
+    "SessionId toString returns value" {
+      val sessionId = "my-session".toSessionId()
+      sessionId.toString() shouldBe "my-session"
+    }
 
-  @Test
-  fun `EMPTY_SESSION_ID has empty value`() {
-    EMPTY_SESSION_ID.value shouldBeEqualTo ""
-  }
+    "EMPTY_SESSION_ID has empty value" {
+      EMPTY_SESSION_ID.value shouldBe ""
+    }
 
-  @Test
-  fun `AssistantId toString returns value`() {
-    val assistantId = "my-assistant".toAssistantId()
-    assistantId.toString() shouldBeEqualTo "my-assistant"
+    "AssistantId toString returns value" {
+      val assistantId = "my-assistant".toAssistantId()
+      assistantId.toString() shouldBe "my-assistant"
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceProviderTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceProviderTest.kt
@@ -31,219 +31,204 @@ import com.vapi4k.api.voice.RimeAIVoiceIdType
 import com.vapi4k.api.voice.RimeAIVoiceModelType
 import com.vapi4k.dsl.vapi4k.Vapi4kConfigImpl
 import com.vapi4k.utils.assistantResponse
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class VoiceProviderTest {
+class VoiceProviderTest : StringSpec() {
   init {
     Vapi4kConfigImpl()
   }
 
-  @Test
-  fun `elevenLabs voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          elevenLabsVoice {
-            voiceIdType = ElevenLabsVoiceIdType.BURT
-            modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
-          }
-        }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "11labs"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "burt"
-    je.stringValue("messageResponse.assistant.voice.model") shouldBeEqualTo "eleven_turbo_v2"
-  }
-
-  @Test
-  fun `elevenLabs voice with customVoiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          elevenLabsVoice {
-            customVoiceId = "my-custom-voice"
-            modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
+  init {
+    "elevenLabs voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            elevenLabsVoice {
+              voiceIdType = ElevenLabsVoiceIdType.BURT
+              modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "11labs"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "my-custom-voice"
-  }
-
-  @Test
-  fun `elevenLabs voice both voiceIdType and customVoiceId throws`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          elevenLabsVoice {
-            voiceIdType = ElevenLabsVoiceIdType.BURT
-            customVoiceId = "custom"
-            modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "elevenLabsVoice{} cannot have both voiceIdType and customVoiceId values"
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "11labs"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "burt"
+      je.stringValue("messageResponse.assistant.voice.model") shouldBe "eleven_turbo_v2"
     }
-  }
 
-  @Test
-  fun `elevenLabs voice missing model throws`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          elevenLabsVoice {
-            voiceIdType = ElevenLabsVoiceIdType.BURT
+    "elevenLabs voice with customVoiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            elevenLabsVoice {
+              customVoiceId = "my-custom-voice"
+              modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
+            }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "elevenLabsVoice{} requires a modelType or customModel value"
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "11labs"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "my-custom-voice"
     }
-  }
 
-  @Test
-  fun `openAI voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          openAIVoice {
-            voiceIdType = OpenAIVoiceIdType.ALLOY
+    "elevenLabs voice both voiceIdType and customVoiceId throws" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            elevenLabsVoice {
+              voiceIdType = ElevenLabsVoiceIdType.BURT
+              customVoiceId = "custom"
+              modelType = ElevenLabsVoiceModelType.ELEVEN_TURBO_V2
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "openai"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "alloy"
-  }
+      }.message shouldBe "elevenLabsVoice{} cannot have both voiceIdType and customVoiceId values"
+    }
 
-  @Test
-  fun `deepgram voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          deepgramVoice {
-            voiceIdType = DeepGramVoiceIdType.ANGUS
+    "elevenLabs voice missing model throws" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            elevenLabsVoice {
+              voiceIdType = ElevenLabsVoiceIdType.BURT
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "deepgram"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "angus"
-  }
+      }.message shouldBe "elevenLabsVoice{} requires a modelType or customModel value"
+    }
 
-  @Test
-  fun `azure voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          azureVoice {
-            voiceIdType = AzureVoiceIdType.ANDREW
+    "openAI voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            openAIVoice {
+              voiceIdType = OpenAIVoiceIdType.ALLOY
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "azure"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "andrew"
-  }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "openai"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "alloy"
+    }
 
-  @Test
-  fun `lmnt voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          lmntVoice {
-            voiceIdType = LMNTVoiceIdType.DANIEL
+    "deepgram voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            deepgramVoice {
+              voiceIdType = DeepGramVoiceIdType.ANGUS
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "lmnt"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "daniel"
-  }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "deepgram"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "angus"
+    }
 
-  @Test
-  fun `rimeAI voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          rimeAIVoice {
-            voiceIdType = RimeAIVoiceIdType.MARSH
-            modelType = RimeAIVoiceModelType.MIST
+    "azure voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            azureVoice {
+              voiceIdType = AzureVoiceIdType.ANDREW
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "rime-ai"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "marsh"
-  }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "azure"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "andrew"
+    }
 
-  @Test
-  fun `neets voice serializes provider and voiceId`() {
-    val response =
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          neetsVoice {
-            voiceIdType = NeetsVoiceIdType.VITS
+    "lmnt voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            lmntVoice {
+              voiceIdType = LMNTVoiceIdType.DANIEL
+            }
           }
         }
-      }
-    val je = response.toJsonElement()
-    je.stringValue("messageResponse.assistant.voice.provider") shouldBeEqualTo "neets"
-    je.stringValue("messageResponse.assistant.voice.voiceId") shouldBeEqualTo "vits"
-  }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "lmnt"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "daniel"
+    }
 
-  @Test
-  fun `double voice blocks throws error`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        assistant {
-          groqModel {
-            modelType = GroqModelType.LLAMA3_8B_8192
-          }
-          openAIVoice {
-            voiceIdType = OpenAIVoiceIdType.ALLOY
-          }
-          deepgramVoice {
-            voiceIdType = DeepGramVoiceIdType.ANGUS
+    "rimeAI voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            rimeAIVoice {
+              voiceIdType = RimeAIVoiceIdType.MARSH
+              modelType = RimeAIVoiceModelType.MIST
+            }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "openAIVoice{} already called"
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "rime-ai"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "marsh"
+    }
+
+    "neets voice serializes provider and voiceId" {
+      val response =
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            neetsVoice {
+              voiceIdType = NeetsVoiceIdType.VITS
+            }
+          }
+        }
+      val je = response.toJsonElement()
+      je.stringValue("messageResponse.assistant.voice.provider") shouldBe "neets"
+      je.stringValue("messageResponse.assistant.voice.voiceId") shouldBe "vits"
+    }
+
+    "double voice blocks throws error" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          assistant {
+            groqModel {
+              modelType = GroqModelType.LLAMA3_8B_8192
+            }
+            openAIVoice {
+              voiceIdType = OpenAIVoiceIdType.ALLOY
+            }
+            deepgramVoice {
+              voiceIdType = DeepGramVoiceIdType.ANGUS
+            }
+          }
+        }
+      }.message shouldBe "openAIVoice{} already called"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
@@ -30,133 +30,124 @@ import com.vapi4k.api.voice.PlayHTVoiceEmotionType
 import com.vapi4k.api.voice.PlayHTVoiceIdType
 import com.vapi4k.api.voice.PunctuationType
 import com.vapi4k.utils.assistantResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.jsonArray
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeTrue
-import org.junit.jupiter.api.Assertions.assertThrows
-import kotlin.test.Test
 
-class VoiceTest {
-  @Test
-  fun `playHt voice basic test`() {
-    val squad =
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
+class VoiceTest : StringSpec() {
+  init {
+    "playHt voice basic test" {
+      val squad =
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
 
-                playHTVoice {
-                  voiceIdType = PlayHTVoiceIdType.MATT
-                  emotion = PlayHTVoiceEmotionType.MALE_SAD
+                  playHTVoice {
+                    voiceIdType = PlayHTVoiceIdType.MATT
+                    emotion = PlayHTVoiceEmotionType.MALE_SAD
+                  }
                 }
               }
             }
           }
         }
-      }
-    val jsonElement = squad.toJsonElement()
-    val members = jsonElement["messageResponse.squad.members"].jsonArray.toList()
-    members.size shouldBeEqualTo 1
-    members.first().stringValue("assistant.name") shouldBeEqualTo "Receptionist"
-    members.first().stringValue("assistant.firstMessage") shouldBeEqualTo "Hi there!"
-    members.first().stringValue("assistant.model.model") shouldBeEqualTo "llama3-8b-8192"
-    members.first().stringValue("assistant.model.provider") shouldBeEqualTo "groq"
-    members.first().stringValue("assistant.voice.voiceId") shouldBeEqualTo "matt"
-    members.first().stringValue("assistant.voice.emotion") shouldBeEqualTo "male_sad"
-  }
-
-  @Test
-  fun `playHt voice two or no voiceId error test`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                playHTVoice {
-                  voiceIdType = PlayHTVoiceIdType.MATT
-                  emotion = PlayHTVoiceEmotionType.MALE_SAD
-                  customVoiceId = "jeff"
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "playHTVoice{} cannot have both voiceIdType and customVoiceId values"
+      val jsonElement = squad.toJsonElement()
+      val members = jsonElement["messageResponse.squad.members"].jsonArray.toList()
+      members.size shouldBe 1
+      members.first().stringValue("assistant.name") shouldBe "Receptionist"
+      members.first().stringValue("assistant.firstMessage") shouldBe "Hi there!"
+      members.first().stringValue("assistant.model.model") shouldBe "llama3-8b-8192"
+      members.first().stringValue("assistant.model.provider") shouldBe "groq"
+      members.first().stringValue("assistant.voice.voiceId") shouldBe "matt"
+      members.first().stringValue("assistant.voice.emotion") shouldBe "male_sad"
     }
 
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
+    "playHt voice two or no voiceId error test" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
 
-                playHTVoice {
-                  emotion = PlayHTVoiceEmotionType.MALE_SAD
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "playHTVoice{} requires a voiceIdType or customVoiceId value"
-    }
-  }
-
-  @Test
-  fun `cartesia voice two or no models error test`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                cartesiaVoice {
-                  voiceId = "matt"
-                  modelType = CartesiaVoiceModelType.SONIC_ENGLISH
-                  customModel = "specialModel"
+                  playHTVoice {
+                    voiceIdType = PlayHTVoiceIdType.MATT
+                    emotion = PlayHTVoiceEmotionType.MALE_SAD
+                    customVoiceId = "jeff"
+                  }
                 }
               }
             }
           }
         }
-      }
-    }.also {
-      it.message shouldBeEqualTo "cartesiaVoice{} cannot have both modelType and customModel values"
+      }.message shouldBe "playHTVoice{} cannot have both voiceIdType and customVoiceId values"
+
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  playHTVoice {
+                    emotion = PlayHTVoiceEmotionType.MALE_SAD
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "playHTVoice{} requires a voiceIdType or customVoiceId value"
     }
 
-//    assertThrows(IllegalStateException::class.java) {
+    "cartesia voice two or no models error test" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  cartesiaVoice {
+                    voiceId = "matt"
+                    modelType = CartesiaVoiceModelType.SONIC_ENGLISH
+                    customModel = "specialModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "cartesiaVoice{} cannot have both modelType and customModel values"
+
+//    shouldThrow<IllegalStateException> {
 //      assistantResponse(newRequestContext()) {
 //        squad {
 //          members {
@@ -177,172 +168,120 @@ class VoiceTest {
 //          }
 //        }
 //      }
-//    }.also {
-//      assertEquals("cartesiaVoice{} requires a modelType or customModel value", it.message)
-//    }
-  }
-
-  @Test
-  fun `cartesia voice two languages error test`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                cartesiaVoice {
-                  voiceId = "matt"
-                  modelType = CartesiaVoiceModelType.SONIC_ENGLISH
-                  languageType = CartesiaVoiceLanguageType.FRENCH
-                  customLanguage = "specialLanguage"
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "cartesiaVoice{} cannot have both languageType and customLanguage values"
+//    }.message shouldBe "cartesiaVoice{} requires a modelType or customModel value"
     }
-  }
 
-  @Test
-  fun `cartesia voice double model error test`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
+    "cartesia voice two languages error test" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                cartesiaVoice {
-                  voiceId = "matt"
-                  modelType = CartesiaVoiceModelType.SONIC_ENGLISH
-                  customModel = "specialModel"
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "groqModel{} already called"
-    }
-  }
-
-  @Test
-  fun `cartesia voice double voice error test`() {
-    assertThrows(IllegalStateException::class.java) {
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                cartesiaVoice {
-                  voiceId = "matt"
-                  modelType = CartesiaVoiceModelType.SONIC_ENGLISH
-                }
-
-                cartesiaVoice {
-                  voiceId = "matt"
-                  modelType = CartesiaVoiceModelType.SONIC_ENGLISH
-                }
-              }
-            }
-          }
-        }
-      }
-    }.also {
-      it.message shouldBeEqualTo "cartesiaVoice{} already called"
-    }
-  }
-
-  @Test
-  fun `chunkPlan serializes as nested JSON`() {
-    val squad =
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
-
-                cartesiaVoice {
-                  voiceId = "test-voice"
-                  chunkPlan {
-                    enabled = true
-                    minCharacters = 40
-                    punctuationBoundaries += PunctuationType.PERIOD
-                    punctuationBoundaries += PunctuationType.COMMA
+                  cartesiaVoice {
+                    voiceId = "matt"
+                    modelType = CartesiaVoiceModelType.SONIC_ENGLISH
+                    languageType = CartesiaVoiceLanguageType.FRENCH
+                    customLanguage = "specialLanguage"
                   }
                 }
               }
             }
           }
         }
-      }
-    val jsonElement = squad.toJsonElement()
-    val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
-    voice.stringValue("provider") shouldBeEqualTo "cartesia"
-    voice.stringValue("voiceId") shouldBeEqualTo "test-voice"
-    voice.booleanValue("chunkPlan.enabled").shouldBeTrue()
-    voice.intValue("chunkPlan.minCharacters") shouldBeEqualTo 40
-    voice["chunkPlan.punctuationBoundaries"].jsonArray.size shouldBeEqualTo 2
-  }
+      }.message shouldBe "cartesiaVoice{} cannot have both languageType and customLanguage values"
+    }
 
-  @Test
-  fun `chunkPlan with nested formatPlan serializes correctly`() {
-    val squad =
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist"
-                firstMessage = "Hi there!"
+    "cartesia voice double model error test" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_8B_8192
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  cartesiaVoice {
+                    voiceId = "matt"
+                    modelType = CartesiaVoiceModelType.SONIC_ENGLISH
+                    customModel = "specialModel"
+                  }
                 }
+              }
+            }
+          }
+        }
+      }.message shouldBe "groqModel{} already called"
+    }
 
-                cartesiaVoice {
-                  voiceId = "test-voice"
-                  fillerInjectionEnabled = true
-                  chunkPlan {
-                    enabled = true
-                    minCharacters = 50
-                    formatPlan {
+    "cartesia voice double voice error test" {
+      shouldThrow<IllegalStateException> {
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  cartesiaVoice {
+                    voiceId = "matt"
+                    modelType = CartesiaVoiceModelType.SONIC_ENGLISH
+                  }
+
+                  cartesiaVoice {
+                    voiceId = "matt"
+                    modelType = CartesiaVoiceModelType.SONIC_ENGLISH
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.message shouldBe "cartesiaVoice{} already called"
+    }
+
+    "chunkPlan serializes as nested JSON" {
+      val squad =
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  cartesiaVoice {
+                    voiceId = "test-voice"
+                    chunkPlan {
                       enabled = true
-                      numberToDigitsCutoff = 2025
+                      minCharacters = 40
+                      punctuationBoundaries += PunctuationType.PERIOD
+                      punctuationBoundaries += PunctuationType.COMMA
                     }
                   }
                 }
@@ -350,56 +289,95 @@ class VoiceTest {
             }
           }
         }
-      }
-    val jsonElement = squad.toJsonElement()
-    val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
-    voice.stringValue("provider") shouldBeEqualTo "cartesia"
-    voice.booleanValue("fillerInjectionEnabled").shouldBeTrue()
-    voice.booleanValue("chunkPlan.enabled").shouldBeTrue()
-    voice.intValue("chunkPlan.minCharacters") shouldBeEqualTo 50
-    voice.booleanValue("chunkPlan.formatPlan.enabled").shouldBeTrue()
-    voice.intValue("chunkPlan.formatPlan.numberToDigitsCutoff") shouldBeEqualTo 2025
-  }
+      val jsonElement = squad.toJsonElement()
+      val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
+      voice.stringValue("provider") shouldBe "cartesia"
+      voice.stringValue("voiceId") shouldBe "test-voice"
+      voice.booleanValue("chunkPlan.enabled") shouldBe true
+      voice.intValue("chunkPlan.minCharacters") shouldBe 40
+      voice["chunkPlan.punctuationBoundaries"].jsonArray.size shouldBe 2
+    }
 
-  @Test
-  fun `double values test`() {
-    val squad =
-      assistantResponse(newRequestContext()) {
-        squad {
-          members {
-            member {
-              assistant {
-                name = "Receptionist 1"
-                name = "Receptionist"
-                firstMessage = "Hi there!"
-                firstMessage = "Hello!"
+    "chunkPlan with nested formatPlan serializes correctly" {
+      val squad =
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
 
-                groqModel {
-                  modelType = GroqModelType.LLAMA3_70B_8192
-                  modelType = GroqModelType.LLAMA3_8B_8192
-                }
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
 
-                playHTVoice {
-                  voiceIdType = PlayHTVoiceIdType.MATT
-                  voiceIdType = PlayHTVoiceIdType.JACK
-                  emotion = PlayHTVoiceEmotionType.MALE_SAD
-                  emotion = PlayHTVoiceEmotionType.MALE_ANGRY
-                  temperature = 5.0
-                  temperature = 10.0
+                  cartesiaVoice {
+                    voiceId = "test-voice"
+                    fillerInjectionEnabled = true
+                    chunkPlan {
+                      enabled = true
+                      minCharacters = 50
+                      formatPlan {
+                        enabled = true
+                        numberToDigitsCutoff = 2025
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         }
+      val jsonElement = squad.toJsonElement()
+      val voice = jsonElement["messageResponse.squad.members"].jsonArray.first()["assistant.voice"]
+      voice.stringValue("provider") shouldBe "cartesia"
+      voice.booleanValue("fillerInjectionEnabled") shouldBe true
+      voice.booleanValue("chunkPlan.enabled") shouldBe true
+      voice.intValue("chunkPlan.minCharacters") shouldBe 50
+      voice.booleanValue("chunkPlan.formatPlan.enabled") shouldBe true
+      voice.intValue("chunkPlan.formatPlan.numberToDigitsCutoff") shouldBe 2025
+    }
+
+    "double values test" {
+      val squad =
+        assistantResponse(newRequestContext()) {
+          squad {
+            members {
+              member {
+                assistant {
+                  name = "Receptionist 1"
+                  name = "Receptionist"
+                  firstMessage = "Hi there!"
+                  firstMessage = "Hello!"
+
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_70B_8192
+                    modelType = GroqModelType.LLAMA3_8B_8192
+                  }
+
+                  playHTVoice {
+                    voiceIdType = PlayHTVoiceIdType.MATT
+                    voiceIdType = PlayHTVoiceIdType.JACK
+                    emotion = PlayHTVoiceEmotionType.MALE_SAD
+                    emotion = PlayHTVoiceEmotionType.MALE_ANGRY
+                    temperature = 5.0
+                    temperature = 10.0
+                  }
+                }
+              }
+            }
+          }
+        }
+      val jsonElement = squad.toJsonElement()
+      val members = jsonElement.jsonElementList("messageResponse.squad.members")
+      with(members.first()) {
+        stringValue("assistant.firstMessage") shouldBe "Hello!"
+        stringValue("assistant.model.model") shouldBe "llama3-8b-8192"
+        stringValue("assistant.voice.voiceId") shouldBe "jack"
+        stringValue("assistant.voice.emotion") shouldBe "male_angry"
+        stringValue("assistant.voice.temperature") shouldBe "10.0"
       }
-    val jsonElement = squad.toJsonElement()
-    val members = jsonElement.jsonElementList("messageResponse.squad.members")
-    with(members.first()) {
-      stringValue("assistant.firstMessage") shouldBeEqualTo "Hello!"
-      stringValue("assistant.model.model") shouldBeEqualTo "llama3-8b-8192"
-      stringValue("assistant.voice.voiceId") shouldBeEqualTo "jack"
-      stringValue("assistant.voice.emotion") shouldBeEqualTo "male_angry"
-      stringValue("assistant.voice.temperature") shouldBeEqualTo "10.0"
     }
   }
 }

--- a/vapi4k-dbms/build.gradle.kts
+++ b/vapi4k-dbms/build.gradle.kts
@@ -18,7 +18,8 @@ dependencies {
     api(libs.exposed.kotlin.datetime)
 
     testImplementation(kotlin("test"))
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
     testImplementation(libs.ktor.server.tests)
 }
 

--- a/vapi4k-utils/build.gradle.kts
+++ b/vapi4k-utils/build.gradle.kts
@@ -36,7 +36,8 @@ dependencies {
     api(libs.kotlin.logging)
     api(libs.logback.classic)
 
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
     testImplementation(kotlin("test"))
 }
 

--- a/vapi4k-utils/src/test/kotlin/com/vapi4k/EnvVarTest.kt
+++ b/vapi4k-utils/src/test/kotlin/com/vapi4k/EnvVarTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.envvar.EnvVar
+import com.vapi4k.envvar.EnvVar.Companion.getWithDefault
+import com.vapi4k.envvar.EnvVar.Companion.isDefined
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class EnvVarTest : StringSpec() {
+  init {
+    "getEnv returns default when env var is not set" {
+      val envVar = EnvVar(
+        name = "TEST_ENVVAR_NONEXISTENT_${System.nanoTime()}",
+        src = getWithDefault("fallback-value"),
+        reportOnBoot = false,
+      )
+      envVar.value shouldBe "fallback-value"
+    }
+
+    "getEnvOrNull returns null when env var is not set" {
+      val envVar = EnvVar(
+        name = "TEST_ENVVAR_MISSING_${System.nanoTime()}",
+        src = getWithDefault("default"),
+        reportOnBoot = false,
+      )
+      envVar.getEnvOrNull() shouldBe null
+    }
+
+    "required EnvVar throws on missing environment variable" {
+      shouldThrow<IllegalStateException> {
+        EnvVar(
+          name = "TEST_REQUIRED_MISSING_${System.nanoTime()}",
+          src = { getRequired() },
+          required = true,
+          reportOnBoot = false,
+        )
+      }.message shouldContain "Missing"
+    }
+
+    "toBoolean converts value correctly" {
+      val envVar = EnvVar(
+        name = "TEST_BOOL_${System.nanoTime()}",
+        src = getWithDefault(true),
+        reportOnBoot = false,
+      )
+      envVar.toBoolean() shouldBe true
+    }
+
+    "toInt converts value correctly" {
+      val envVar = EnvVar(
+        name = "TEST_INT_${System.nanoTime()}",
+        src = getWithDefault(42),
+        reportOnBoot = false,
+      )
+      envVar.toInt() shouldBe 42
+    }
+
+    "isDefined returns false for unset environment variable" {
+      "TEST_UNDEFINED_VAR_${System.nanoTime()}".isDefined() shouldBe false
+    }
+
+    "isDefined returns true for PATH which is always set" {
+      "PATH".isDefined() shouldBe true
+    }
+
+    "toString returns the value" {
+      val envVar = EnvVar(
+        name = "TEST_TOSTRING_${System.nanoTime()}",
+        src = getWithDefault("hello"),
+        reportOnBoot = false,
+      )
+      envVar.toString() shouldBe "hello"
+    }
+
+    "obfuscate masks characters at given frequency" {
+      val maskFunc = EnvVar.obfuscate(2)
+      maskFunc("abcdef") shouldBe "*b*d*f"
+    }
+
+    "getEnv with boolean default returns default when not set" {
+      val envVar = EnvVar(
+        name = "TEST_BOOL_DEFAULT_${System.nanoTime()}",
+        src = getWithDefault(false),
+        reportOnBoot = false,
+      )
+      envVar.getEnv(true) shouldBe true
+    }
+
+    "getEnv with int default returns default when not set" {
+      val envVar = EnvVar(
+        name = "TEST_INT_DEFAULT_${System.nanoTime()}",
+        src = getWithDefault(99),
+        reportOnBoot = false,
+      )
+      envVar.getEnv(100) shouldBe 100
+    }
+  }
+}

--- a/vapi4k-utils/src/test/kotlin/com/vapi4k/ServerRequestTypeTest.kt
+++ b/vapi4k-utils/src/test/kotlin/com/vapi4k/ServerRequestTypeTest.kt
@@ -22,79 +22,68 @@ import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isAssistantRequest
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isEndOfCallReport
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isToolCall
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.serverRequestType
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class ServerRequestTypeTest {
-  @Test
-  fun `serverRequestType parses assistant-request`() {
-    val json = """{"message": {"type": "assistant-request"}}""".toJsonElement()
-    json.serverRequestType shouldBeEqualTo ServerRequestType.ASSISTANT_REQUEST
-  }
+class ServerRequestTypeTest : StringSpec() {
+  init {
+    "serverRequestType parses assistant-request" {
+      val json = """{"message": {"type": "assistant-request"}}""".toJsonElement()
+      json.serverRequestType shouldBe ServerRequestType.ASSISTANT_REQUEST
+    }
 
-  @Test
-  fun `serverRequestType parses end-of-call-report`() {
-    val json = """{"message": {"type": "end-of-call-report"}}""".toJsonElement()
-    json.serverRequestType shouldBeEqualTo ServerRequestType.END_OF_CALL_REPORT
-  }
+    "serverRequestType parses end-of-call-report" {
+      val json = """{"message": {"type": "end-of-call-report"}}""".toJsonElement()
+      json.serverRequestType shouldBe ServerRequestType.END_OF_CALL_REPORT
+    }
 
-  @Test
-  fun `serverRequestType parses tool-calls`() {
-    val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
-    json.serverRequestType shouldBeEqualTo ServerRequestType.TOOL_CALL
-  }
+    "serverRequestType parses tool-calls" {
+      val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
+      json.serverRequestType shouldBe ServerRequestType.TOOL_CALL
+    }
 
-  @Test
-  fun `serverRequestType parses function-call`() {
-    val json = """{"message": {"type": "function-call"}}""".toJsonElement()
-    json.serverRequestType shouldBeEqualTo ServerRequestType.FUNCTION_CALL
-  }
+    "serverRequestType parses function-call" {
+      val json = """{"message": {"type": "function-call"}}""".toJsonElement()
+      json.serverRequestType shouldBe ServerRequestType.FUNCTION_CALL
+    }
 
-  @Test
-  fun `serverRequestType returns UNKNOWN for invalid type`() {
-    val json = """{"message": {"type": "does-not-exist"}}""".toJsonElement()
-    json.serverRequestType shouldBeEqualTo ServerRequestType.UNKNOWN_REQUEST_TYPE
-  }
+    "serverRequestType returns UNKNOWN for invalid type" {
+      val json = """{"message": {"type": "does-not-exist"}}""".toJsonElement()
+      json.serverRequestType shouldBe ServerRequestType.UNKNOWN_REQUEST_TYPE
+    }
 
-  @Test
-  fun `isAssistantRequest returns true for assistant-request`() {
-    val json = """{"message": {"type": "assistant-request"}}""".toJsonElement()
-    json.isAssistantRequest().shouldBeTrue()
-  }
+    "isAssistantRequest returns true for assistant-request" {
+      val json = """{"message": {"type": "assistant-request"}}""".toJsonElement()
+      json.isAssistantRequest() shouldBe true
+    }
 
-  @Test
-  fun `isAssistantRequest returns false for other types`() {
-    val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
-    json.isAssistantRequest().shouldBeFalse()
-  }
+    "isAssistantRequest returns false for other types" {
+      val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
+      json.isAssistantRequest() shouldBe false
+    }
 
-  @Test
-  fun `isEndOfCallReport returns true for end-of-call-report`() {
-    val json = """{"message": {"type": "end-of-call-report"}}""".toJsonElement()
-    json.isEndOfCallReport().shouldBeTrue()
-  }
+    "isEndOfCallReport returns true for end-of-call-report" {
+      val json = """{"message": {"type": "end-of-call-report"}}""".toJsonElement()
+      json.isEndOfCallReport() shouldBe true
+    }
 
-  @Test
-  fun `isToolCall returns true for tool-calls`() {
-    val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
-    json.isToolCall().shouldBeTrue()
-  }
+    "isToolCall returns true for tool-calls" {
+      val json = """{"message": {"type": "tool-calls"}}""".toJsonElement()
+      json.isToolCall() shouldBe true
+    }
 
-  @Test
-  fun `all ServerRequestType entries have unique desc values`() {
-    val descs = ServerRequestType.entries.map { it.desc }
-    descs.size shouldBeEqualTo descs.toSet().size
-  }
+    "all ServerRequestType entries have unique desc values" {
+      val descs = ServerRequestType.entries.map { it.desc }
+      descs.size shouldBe descs.toSet().size
+    }
 
-  @Test
-  fun `serverRequestType parses all known types`() {
-    ServerRequestType.entries
-      .filter { it != ServerRequestType.UNKNOWN_REQUEST_TYPE }
-      .forEach { type ->
-        val json = """{"message": {"type": "${type.desc}"}}""".toJsonElement()
-        json.serverRequestType shouldBeEqualTo type
-      }
+    "serverRequestType parses all known types" {
+      ServerRequestType.entries
+        .filter { it != ServerRequestType.UNKNOWN_REQUEST_TYPE }
+        .forEach { type ->
+          val json = """{"message": {"type": "${type.desc}"}}""".toJsonElement()
+          json.serverRequestType shouldBe type
+        }
+    }
   }
 }

--- a/vapi4k-utils/src/test/kotlin/com/vapi4k/UtilsTest.kt
+++ b/vapi4k-utils/src/test/kotlin/com/vapi4k/UtilsTest.kt
@@ -27,127 +27,104 @@ import com.vapi4k.common.Utils.lpad
 import com.vapi4k.common.Utils.obfuscate
 import com.vapi4k.common.Utils.rpad
 import com.vapi4k.common.Utils.trimLeadingSpaces
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
-import kotlin.test.Test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class UtilsTest {
-  @Test
-  fun `ensureStartsWith already has prefix`() {
-    "/path".ensureStartsWith("/") shouldBeEqualTo "/path"
-  }
+class UtilsTest : StringSpec() {
+  init {
+    "ensureStartsWith already has prefix" {
+      "/path".ensureStartsWith("/") shouldBe "/path"
+    }
 
-  @Test
-  fun `ensureStartsWith missing prefix`() {
-    "path".ensureStartsWith("/") shouldBeEqualTo "/path"
-  }
+    "ensureStartsWith missing prefix" {
+      "path".ensureStartsWith("/") shouldBe "/path"
+    }
 
-  @Test
-  fun `ensureStartsWith with multi-char prefix`() {
-    "example.com".ensureStartsWith("https://") shouldBeEqualTo "https://example.com"
-    "https://example.com".ensureStartsWith("https://") shouldBeEqualTo "https://example.com"
-  }
+    "ensureStartsWith with multi-char prefix" {
+      "example.com".ensureStartsWith("https://") shouldBe "https://example.com"
+      "https://example.com".ensureStartsWith("https://") shouldBe "https://example.com"
+    }
 
-  @Test
-  fun `ensureEndsWith already has suffix`() {
-    "file.kt".ensureEndsWith(".kt") shouldBeEqualTo "file.kt"
-  }
+    "ensureEndsWith already has suffix" {
+      "file.kt".ensureEndsWith(".kt") shouldBe "file.kt"
+    }
 
-  @Test
-  fun `ensureEndsWith missing suffix`() {
-    "file".ensureEndsWith(".kt") shouldBeEqualTo "file.kt"
-  }
+    "ensureEndsWith missing suffix" {
+      "file".ensureEndsWith(".kt") shouldBe "file.kt"
+    }
 
-  @Test
-  fun `trimLeadingSpaces preserves newlines`() {
-    val input = "  line1\n    line2\n  line3"
-    val expected = "line1\nline2\nline3"
-    input.trimLeadingSpaces() shouldBeEqualTo expected
-  }
+    "trimLeadingSpaces preserves newlines" {
+      val input = "  line1\n    line2\n  line3"
+      val expected = "line1\nline2\nline3"
+      input.trimLeadingSpaces() shouldBe expected
+    }
 
-  @Test
-  fun `trimLeadingSpaces with no leading spaces`() {
-    "abc\ndef".trimLeadingSpaces() shouldBeEqualTo "abc\ndef"
-  }
+    "trimLeadingSpaces with no leading spaces" {
+      "abc\ndef".trimLeadingSpaces() shouldBe "abc\ndef"
+    }
 
-  @Test
-  fun `obfuscate with default freq`() {
-    val result = "abcdef".obfuscate()
-    // freq=2 means index 0,2,4 are replaced with '*'
-    result shouldBeEqualTo "*b*d*f"
-  }
+    "obfuscate with default freq" {
+      val result = "abcdef".obfuscate()
+      result shouldBe "*b*d*f"
+    }
 
-  @Test
-  fun `obfuscate with freq 3`() {
-    val result = "abcdef".obfuscate(3)
-    // freq=3 means index 0,3 are replaced with '*'
-    result shouldBeEqualTo "*bc*ef"
-  }
+    "obfuscate with freq 3" {
+      val result = "abcdef".obfuscate(3)
+      result shouldBe "*bc*ef"
+    }
 
-  @Test
-  fun `obfuscate empty string`() {
-    "".obfuscate() shouldBeEqualTo ""
-  }
+    "obfuscate empty string" {
+      "".obfuscate() shouldBe ""
+    }
 
-  @Test
-  fun `capitalizeFirstChar with mixed case`() {
-    "hELLO".capitalizeFirstChar() shouldBeEqualTo "Hello"
-  }
+    "capitalizeFirstChar with mixed case" {
+      "hELLO".capitalizeFirstChar() shouldBe "Hello"
+    }
 
-  @Test
-  fun `capitalizeFirstChar with lowercase`() {
-    "world".capitalizeFirstChar() shouldBeEqualTo "World"
-  }
+    "capitalizeFirstChar with lowercase" {
+      "world".capitalizeFirstChar() shouldBe "World"
+    }
 
-  @Test
-  fun `capitalizeFirstChar with already capitalized`() {
-    "Hello".capitalizeFirstChar() shouldBeEqualTo "Hello"
-  }
+    "capitalizeFirstChar with already capitalized" {
+      "Hello".capitalizeFirstChar() shouldBe "Hello"
+    }
 
-  @Test
-  fun `encode and decode round-trip`() {
-    val original = "a b&c=d+e"
-    original.encode().decode() shouldBeEqualTo original
-  }
+    "encode and decode round-trip" {
+      val original = "a b&c=d+e"
+      original.encode().decode() shouldBe original
+    }
 
-  @Test
-  fun `encode special characters`() {
-    val encoded = "hello world".encode()
-    encoded shouldBeEqualTo "hello+world"
-  }
+    "encode special characters" {
+      val encoded = "hello world".encode()
+      encoded shouldBe "hello+world"
+    }
 
-  @Test
-  fun `isNull and isNotNull with null`() {
-    val value: String? = null
-    value.isNull().shouldBeTrue()
-    value.isNotNull().shouldBeFalse()
-  }
+    "isNull and isNotNull with null" {
+      val value: String? = null
+      value.isNull() shouldBe true
+      value.isNotNull() shouldBe false
+    }
 
-  @Test
-  fun `isNull and isNotNull with non-null`() {
-    val value: String? = "hello"
-    value.isNull().shouldBeFalse()
-    value.isNotNull().shouldBeTrue()
-  }
+    "isNull and isNotNull with non-null" {
+      val value: String? = "hello"
+      value.isNull() shouldBe false
+      value.isNotNull() shouldBe true
+    }
 
-  @Test
-  fun `lpad pads with zeros`() {
-    42.lpad(5) shouldBeEqualTo "00042"
-  }
+    "lpad pads with zeros" {
+      42.lpad(5) shouldBe "00042"
+    }
 
-  @Test
-  fun `lpad with custom char`() {
-    7.lpad(3, ' ') shouldBeEqualTo "  7"
-  }
+    "lpad with custom char" {
+      7.lpad(3, ' ') shouldBe "  7"
+    }
 
-  @Test
-  fun `rpad pads with zeros`() {
-    42.rpad(5) shouldBeEqualTo "42000"
-  }
+    "rpad pads with zeros" {
+      42.rpad(5) shouldBe "42000"
+    }
 
-  @Test
-  fun `rpad with custom char`() {
-    7.rpad(3, ' ') shouldBeEqualTo "7  "
+    "rpad with custom char" {
+      7.rpad(3, ' ') shouldBe "7  "
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Migrate all 27 test files** from JUnit 5 `@Test` + Kluent assertions to Kotest `StringSpec()` with `init {}` blocks and Kotest assertions
- **Add 11 new test files** (80 tests) covering previously untested areas: `ServiceCache`, `FunctionDetails`, `ManualToolCache`, `ReflectionUtils`, `MiscUtils`, `EnvVar`, transfer destinations, EOCR cache lifecycle, server routing, enum serialization, and `ApplicationType`
- **Remove kluent dependency** entirely from all modules and the version catalog
- **Add kotest 6.0.0.M4** (`kotest-runner-junit5` + `kotest-assertions-core`) to all modules
- **Update docs** (CLAUDE.md, README.md, llms.txt) to reflect the new test framework

233 tests passing, lint clean.

## Test plan

- [x] `./gradlew test` — all 233 tests pass
- [x] `./gradlew lintKotlin` — no lint errors
- [x] No remaining `import org.amshove.kluent`, `import kotlin.test.Test`, or `import org.junit.jupiter` imports
- [x] Kluent fully removed from version catalog and all build files

🤖 Generated with [Claude Code](https://claude.com/claude-code)