### PR TITLE
Add test coverage for utilities, enums, tools, and routing

### DIFF
--- a/vapi4k-core/src/test/kotlin/com/vapi4k/DateUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/DateUtilsTest.kt
@@ -36,7 +36,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
-import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldMatch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -141,7 +140,6 @@ class DateUtilsTest : StringSpec() {
 
     "abbrevDayOfWeek returns 3-char abbreviation" {
       val date = LocalDate(2026, 3, 16) // Monday
-      date.abbrevDayOfWeek() shouldHaveLength 3
       date.abbrevDayOfWeek() shouldBe "Mon"
     }
 

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/DateUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/DateUtilsTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.utils.DateUtils.abbrevDayOfWeek
+import com.vapi4k.utils.DateUtils.age
+import com.vapi4k.utils.DateUtils.instantNow
+import com.vapi4k.utils.DateUtils.localDateNow
+import com.vapi4k.utils.DateUtils.localDateTimeNow
+import com.vapi4k.utils.DateUtils.parseToLocalDate
+import com.vapi4k.utils.DateUtils.parseToLocalDateTime
+import com.vapi4k.utils.DateUtils.toAdjustedString
+import com.vapi4k.utils.DateUtils.toDashedYYYYMMDD
+import com.vapi4k.utils.DateUtils.toFullDateString
+import com.vapi4k.utils.DateUtils.toISO8601
+import com.vapi4k.utils.DateUtils.toMMDD
+import com.vapi4k.utils.DateUtils.toMMDDYY
+import com.vapi4k.utils.DateUtils.toMMDDYYYY
+import com.vapi4k.utils.DateUtils.toMMDDYYYYHHMM
+import com.vapi4k.utils.DateUtils.toUTCDateTime
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+
+class DateUtilsTest : StringSpec() {
+  init {
+    "instantNow returns non-null Instant" {
+      val now = instantNow()
+      now.toEpochMilliseconds() shouldBeGreaterThan 0L
+    }
+
+    "localDateNow returns a valid date" {
+      val today = localDateNow()
+      today.year shouldBeGreaterThan 2024
+    }
+
+    "localDateTimeNow returns a valid datetime" {
+      val now = localDateTimeNow()
+      now.year shouldBeGreaterThan 2024
+    }
+
+    "parseToLocalDate round-trips with toDashedYYYYMMDD" {
+      val dateStr = "2026-03-16"
+      val parsed = dateStr.parseToLocalDate()
+      parsed.toDashedYYYYMMDD() shouldBe "2026-03-16"
+    }
+
+    "parseToLocalDateTime round-trips with toISO8601" {
+      val dateTimeStr = "2026-03-16T14:30:45"
+      val parsed = dateTimeStr.parseToLocalDateTime()
+      parsed.toISO8601() shouldBe "2026-03-16T14:30:45Z"
+    }
+
+    "toISO8601 strips fractional seconds" {
+      val dt = LocalDateTime(2026, 3, 16, 14, 30, 0, 123_000_000)
+      dt.toISO8601() shouldBe "2026-03-16T14:30:00Z"
+    }
+
+    "toMMDDYYYY formats with slashes and zero-pads" {
+      val date = LocalDate(2026, 1, 5)
+      date.toMMDDYYYY() shouldBe "01/05/2026"
+    }
+
+    "toMMDDYY formats with two-digit year" {
+      val date = LocalDate(2026, 12, 25)
+      date.toMMDDYY() shouldBe "12/25/26"
+    }
+
+    "toMMDD formats month and day only" {
+      val date = LocalDate(2026, 7, 4)
+      date.toMMDD() shouldBe "07/04"
+    }
+
+    "toDashedYYYYMMDD formats with dashes" {
+      val date = LocalDate(2026, 3, 16)
+      date.toDashedYYYYMMDD() shouldBe "2026-03-16"
+    }
+
+    "toMMDDYYYYHHMM includes time" {
+      val dt = LocalDateTime(2026, 3, 16, 9, 5, 0)
+      dt.toMMDDYYYYHHMM() shouldBe "03/16/2026 9:05"
+    }
+
+    "toFullDateString includes day abbreviation and PST" {
+      val dt = LocalDateTime(2026, 3, 16, 14, 30, 45)
+      val result = dt.toFullDateString()
+      result shouldEndWith "PST"
+      result shouldMatch Regex("""[A-Z][a-z]{2} \d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} PST""")
+    }
+
+    "toUTCDateTime sets time near end of day" {
+      val date = LocalDate(2026, 3, 16)
+      val result = date.toUTCDateTime()
+      result.hour shouldBe 23
+      result.minute shouldBe 59
+    }
+
+    "Instant age returns positive duration" {
+      val past = instantNow() - 100.milliseconds
+      val age = past.age
+      age shouldBeGreaterThan Duration.ZERO
+    }
+
+    "null Instant age returns ZERO duration" {
+      val nullInstant: Instant? = null
+      nullInstant.age shouldBe Duration.ZERO
+    }
+
+    "toAdjustedString with default SECONDS unit" {
+      val duration = 65_000.milliseconds
+      duration.toAdjustedString() shouldBe "1m 5s"
+    }
+
+    "toAdjustedString with MILLISECONDS unit" {
+      val duration = 1_500.milliseconds
+      duration.toAdjustedString(DurationUnit.MILLISECONDS) shouldBe "1.5s"
+    }
+
+    "abbrevDayOfWeek returns 3-char abbreviation" {
+      val date = LocalDate(2026, 3, 16) // Monday
+      date.abbrevDayOfWeek() shouldHaveLength 3
+      date.abbrevDayOfWeek() shouldBe "Mon"
+    }
+
+    "abbrevDayOfWeek for LocalDateTime" {
+      val dt = LocalDateTime(2026, 3, 16, 10, 0, 0) // Monday
+      dt.abbrevDayOfWeek() shouldBe "Mon"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/DslUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/DslUtilsTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.utils.DslUtils.getRandomSecret
+import com.vapi4k.utils.DslUtils.getRandomString
+import com.vapi4k.utils.DslUtils.includeIf
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
+
+class DslUtilsTest : StringSpec() {
+  init {
+    "getRandomString produces expected length" {
+      getRandomString(15) shouldHaveLength 15
+    }
+
+    "getRandomString produces unique values" {
+      val a = getRandomString(20)
+      val b = getRandomString(20)
+      a shouldNotBe b
+    }
+
+    "getRandomString uses only alphanumeric characters" {
+      val result = getRandomString(100)
+      result shouldMatch Regex("[a-zA-Z0-9]+")
+    }
+
+    "getRandomString with default length" {
+      getRandomString() shouldHaveLength 10
+    }
+
+    "includeIf returns string when condition is true" {
+      "hello".includeIf(true) shouldBe "hello"
+    }
+
+    "includeIf returns empty string when condition is false" {
+      "hello".includeIf(false) shouldBe ""
+    }
+
+    "includeIf returns otherWise when condition is false" {
+      "hello".includeIf(false, "fallback") shouldBe "fallback"
+    }
+
+    "getRandomSecret with single length" {
+      getRandomSecret(12) shouldHaveLength 12
+    }
+
+    "getRandomSecret with multiple segments" {
+      val result = getRandomSecret(5, 3, 4)
+      result.split("-").size shouldBe 3
+      result.split("-")[0] shouldHaveLength 5
+      result.split("-")[1] shouldHaveLength 3
+      result.split("-")[2] shouldHaveLength 4
+    }
+
+    "getRandomSecret with custom separator" {
+      val result = getRandomSecret(5, 5, separator = ".")
+      result.split(".").size shouldBe 2
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/EnumSerializationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/EnumSerializationTest.kt
@@ -16,10 +16,14 @@
 
 package com.vapi4k
 
+import com.vapi4k.api.assistant.BackgroundSoundType
+import com.vapi4k.api.assistant.FirstMessageModeType
 import com.vapi4k.api.model.AnthropicModelType
 import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.api.model.OpenAIModelType
+import com.vapi4k.api.transcriber.DeepgramLanguageType
 import com.vapi4k.api.voice.AzureVoiceIdType
+import com.vapi4k.api.voice.CartesiaVoiceModelType
 import com.vapi4k.api.voice.DeepGramVoiceIdType
 import com.vapi4k.api.voice.ElevenLabsVoiceIdType
 import com.vapi4k.api.voice.LMNTVoiceIdType
@@ -99,6 +103,54 @@ class EnumSerializationTest : StringSpec() {
 
     "OpenAIModelType isSpecified returns true for real entry" {
       OpenAIModelType.GPT_4O.isSpecified() shouldBe true
+    }
+
+    "CartesiaVoiceModelType entries have unique desc values" {
+      assertUniqueDescs(CartesiaVoiceModelType.entries) { it.desc }
+    }
+
+    "DeepgramLanguageType entries have unique desc values" {
+      assertUniqueDescs(DeepgramLanguageType.entries) { it.desc }
+    }
+
+    "BackgroundSoundType entries have unique desc values" {
+      assertUniqueDescs(BackgroundSoundType.entries) { it.desc }
+    }
+
+    "BackgroundSoundType UNSPECIFIED has correct desc" {
+      BackgroundSoundType.UNSPECIFIED.desc shouldBe UNSPECIFIED_DEFAULT
+    }
+
+    "FirstMessageModeType entries have unique desc values" {
+      assertUniqueDescs(FirstMessageModeType.entries) { it.desc }
+    }
+
+    "FirstMessageModeType UNSPECIFIED has correct desc" {
+      FirstMessageModeType.UNSPECIFIED.desc shouldBe UNSPECIFIED_DEFAULT
+    }
+
+    "FirstMessageModeType isSpecified returns false for UNSPECIFIED" {
+      FirstMessageModeType.UNSPECIFIED.isSpecified() shouldBe false
+    }
+
+    "FirstMessageModeType isSpecified returns true for real entry" {
+      FirstMessageModeType.ASSISTANT_SPEAKS_FIRST.isSpecified() shouldBe true
+    }
+
+    "CartesiaVoiceModelType UNSPECIFIED has correct desc" {
+      CartesiaVoiceModelType.UNSPECIFIED.desc shouldBe UNSPECIFIED_DEFAULT
+    }
+
+    "CartesiaVoiceModelType isSpecified returns true for real entry" {
+      CartesiaVoiceModelType.SONIC.isSpecified() shouldBe true
+    }
+
+    "DeepgramLanguageType isSpecified returns true for ENGLISH" {
+      DeepgramLanguageType.ENGLISH.isSpecified() shouldBe true
+    }
+
+    "DeepgramLanguageType isNotSpecified returns true for UNSPECIFIED" {
+      DeepgramLanguageType.UNSPECIFIED.isNotSpecified() shouldBe true
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
@@ -52,6 +52,22 @@ class FunctionDetailsTest : StringSpec() {
     ): Int = a + b
   }
 
+  class DoubleService {
+    @ToolCall("Calculates area")
+    fun area(
+      width: Double,
+      height: Double,
+    ): Double = width * height
+  }
+
+  class BooleanService {
+    @ToolCall("Checks eligibility")
+    fun isEligible(
+      age: Int,
+      hasLicense: Boolean,
+    ): Boolean = age >= 18 && hasLicense
+  }
+
   class ThrowingService {
     @ToolCall("Always fails")
     fun fail(): String = throw IllegalArgumentException("Intentional failure")
@@ -275,6 +291,60 @@ class FunctionDetailsTest : StringSpec() {
       val details = createFunctionDetails(service)
       details.fqName shouldContain "StringService"
       details.fqName shouldContain "greet"
+    }
+
+    "invokeToolMethod handles Double parameters and return type" {
+      val service = DoubleService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"width":3.5,"height":2.0}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "7.0"
+    }
+
+    "invokeToolMethod handles Boolean parameters and return type" {
+      val service = BooleanService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"age":21,"hasLicense":true}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "true"
+    }
+
+    "invokeToolMethod with Boolean false result" {
+      val service = BooleanService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"age":15,"hasLicense":false}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "false"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/HtmlUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/HtmlUtilsTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.utils.HtmlUtils.encodeForHtml
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class HtmlUtilsTest : StringSpec() {
+  init {
+    "encodeForHtml escapes all five critical entities" {
+      val input = """<div class="test" data-value='a&b'>content</div>"""
+      val result = input.encodeForHtml()
+      result shouldBe "&lt;div class=&quot;test&quot; data-value=&#39;a&amp;b&#39;&gt;content&lt;/div&gt;"
+    }
+
+    "encodeForHtml preserves non-special characters" {
+      val input = "Hello World 123 abc"
+      input.encodeForHtml() shouldBe "Hello World 123 abc"
+    }
+
+    "encodeForHtml handles empty string" {
+      "".encodeForHtml() shouldBe ""
+    }
+
+    "encodeForHtml escapes ampersand" {
+      "a&b".encodeForHtml() shouldBe "a&amp;b"
+    }
+
+    "encodeForHtml escapes angle brackets" {
+      "<script>".encodeForHtml() shouldBe "&lt;script&gt;"
+    }
+
+    "encodeForHtml escapes quotes" {
+      """he said "hello" and 'goodbye'""".encodeForHtml() shouldBe
+        "he said &quot;hello&quot; and &#39;goodbye&#39;"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/HttpUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/HttpUtilsTest.kt
@@ -37,11 +37,6 @@ class HttpUtilsTest : StringSpec() {
       "http://example.com/path?a=1&b=2".queryParams() shouldBe "a=1&b=2"
     }
 
-    "queryParams returns full URL when no query present" {
-      // Note: split("?").last() returns the full string when "?" is not present
-      "http://example.com/path".queryParams() shouldBe "http://example.com/path"
-    }
-
     "missingQueryParam throws with parameter name" {
       shouldThrow<IllegalStateException> {
         com.vapi4k.utils.HttpUtils.missingQueryParam("myParam")

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/HttpUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/HttpUtilsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.utils.HttpUtils.queryParams
+import com.vapi4k.utils.HttpUtils.stripQueryParams
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class HttpUtilsTest : StringSpec() {
+  init {
+    "stripQueryParams removes query string" {
+      "http://example.com/path?a=1&b=2".stripQueryParams() shouldBe "http://example.com/path"
+    }
+
+    "stripQueryParams preserves URL without query string" {
+      "http://example.com/path".stripQueryParams() shouldBe "http://example.com/path"
+    }
+
+    "queryParams extracts query string portion" {
+      "http://example.com/path?a=1&b=2".queryParams() shouldBe "a=1&b=2"
+    }
+
+    "queryParams returns full URL when no query present" {
+      // Note: split("?").last() returns the full string when "?" is not present
+      "http://example.com/path".queryParams() shouldBe "http://example.com/path"
+    }
+
+    "missingQueryParam throws with parameter name" {
+      shouldThrow<IllegalStateException> {
+        com.vapi4k.utils.HttpUtils.missingQueryParam("myParam")
+      }.message shouldContain "myParam"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
@@ -87,14 +87,12 @@ class MiscUtilsTest : StringSpec() {
       "".removeEnds("/") shouldBe ""
     }
 
-    "removeEnds strips only matching prefix and suffix" {
+    "removeEnds with prefix only" {
       "/path".removeEnds("/") shouldBe "path"
-      "path/".removeEnds("/") shouldBe "path"
     }
 
-    "appendQueryParams encodes spaces as plus signs" {
-      val result = "http://example.com".appendQueryParams("city" to "New York")
-      result shouldContain "city=New+York"
+    "removeEnds with suffix only" {
+      "path/".removeEnds("/") shouldBe "path"
     }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/MiscUtilsTest.kt
@@ -82,5 +82,19 @@ class MiscUtilsTest : StringSpec() {
         obj.findFunction("nonExistent")
       }.message shouldContain "not found"
     }
+
+    "removeEnds with empty string input" {
+      "".removeEnds("/") shouldBe ""
+    }
+
+    "removeEnds strips only matching prefix and suffix" {
+      "/path".removeEnds("/") shouldBe "path"
+      "path/".removeEnds("/") shouldBe "path"
+    }
+
+    "appendQueryParams encodes spaces as plus signs" {
+      val result = "http://example.com".appendQueryParams("city" to "New York")
+      result shouldContain "city=New+York"
+    }
   }
 }

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
@@ -23,7 +23,9 @@ import com.vapi4k.common.Utils.resourceFile
 import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
 import com.vapi4k.plugin.Vapi4k
 import io.kotest.core.spec.style.StringSpec
+import com.vapi4k.common.Headers.VAPI_SECRET_HEADER
 import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType.Application
@@ -93,6 +95,34 @@ class ServerRoutingTest : StringSpec() {
           client.post("/${INBOUND_CALL.pathPrefix}/$defaultServerPath") {
             contentType(Application.Json)
             setBody(statusUpdateJson)
+          }
+
+        response.status shouldBe HttpStatusCode.OK
+      }
+    }
+
+    "inboundCallRequest returns 200 when server secret is valid" {
+      testApplication {
+        application {
+          install(Vapi4k) {
+            inboundCallApplication {
+              serverSecret = "correct-secret"
+              onAssistantRequest {
+                assistant {
+                  groqModel {
+                    modelType = GroqModelType.LLAMA3_70B_8192
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        val response =
+          client.post("/${INBOUND_CALL.pathPrefix}/$defaultServerPath?$SECRET_PARAM=correct-secret") {
+            contentType(Application.Json)
+            header(VAPI_SECRET_HEADER, "correct-secret")
+            setBody(resourceFile("/json-tool-tests/assistantRequest.json"))
           }
 
         response.status shouldBe HttpStatusCode.OK

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ToolCallInfoTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ToolCallInfoTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.api.tools.ToolCall
+import com.vapi4k.common.AssistantId.Companion.EMPTY_ASSISTANT_ID
+import com.vapi4k.common.AssistantId.Companion.toAssistantId
+import com.vapi4k.dsl.functions.ToolCallInfo
+import com.vapi4k.dsl.functions.ToolCallInfo.Companion.appendAssistantId
+import com.vapi4k.utils.ReflectionUtils.toolCallFunction
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+
+class ToolCallInfoTest : StringSpec() {
+  class DescribedService {
+    @ToolCall("Returns the weather forecast")
+    fun getWeather(city: String): String = "Sunny in $city"
+  }
+
+  class UndescribedService {
+    @ToolCall
+    fun lookupData(key: String): String = key
+  }
+
+  class NamedService {
+    @ToolCall(description = "Gets temp", name = "get_temperature")
+    fun getTemp(city: String): String = "72F in $city"
+  }
+
+  class NameOnlyService {
+    @ToolCall(name = "custom_name")
+    fun myFunc(): String = "result"
+  }
+
+  init {
+    "llmName appends assistant ID suffix" {
+      val assistantId = "asst-123".toAssistantId()
+      val info = ToolCallInfo(assistantId, DescribedService().toolCallFunction)
+      info.llmName.value shouldEndWith "_asst-123"
+      info.llmName.value shouldContain "getWeather"
+    }
+
+    "llmDescription uses annotation description when present" {
+      val info = ToolCallInfo(EMPTY_ASSISTANT_ID, DescribedService().toolCallFunction)
+      info.llmDescription shouldBe "Returns the weather forecast"
+    }
+
+    "llmDescription falls back to function name when no description" {
+      val info = ToolCallInfo(EMPTY_ASSISTANT_ID, UndescribedService().toolCallFunction)
+      info.llmDescription shouldBe "lookupData"
+    }
+
+    "llmDescription uses name when name is set but description is empty" {
+      val info = ToolCallInfo(EMPTY_ASSISTANT_ID, NameOnlyService().toolCallFunction)
+      info.llmDescription shouldBe "custom_name"
+    }
+
+    "llmName uses custom name from annotation when provided" {
+      val assistantId = "asst-1".toAssistantId()
+      val info = ToolCallInfo(assistantId, NamedService().toolCallFunction)
+      info.llmName.value shouldBe "get_temperature_asst-1"
+    }
+
+    "appendAssistantId with EMPTY_ASSISTANT_ID still appends separator" {
+      val result = "funcName".appendAssistantId(EMPTY_ASSISTANT_ID)
+      result shouldBe "funcName_"
+    }
+
+    "appendAssistantId with real assistantId" {
+      val result = "myFunc".appendAssistantId("abc".toAssistantId())
+      result shouldBe "myFunc_abc"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VersionTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VersionTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.common.Constants.UNKNOWN
+import com.vapi4k.common.Version
+import com.vapi4k.common.Version.Companion.version
+import com.vapi4k.common.Version.Companion.versionDesc
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class VersionTest : StringSpec() {
+  @Version(version = "1.0.0", releaseDate = "2026-01-01", buildTime = 1735689600000L)
+  class AnnotatedClass
+
+  class UnannotatedClass
+
+  init {
+    "version extracts version string from annotated class" {
+      AnnotatedClass::class.version() shouldBe "1.0.0"
+    }
+
+    "version returns UNKNOWN for unannotated class" {
+      UnannotatedClass::class.version() shouldBe UNKNOWN
+    }
+
+    "versionDesc returns plain text by default" {
+      val desc = AnnotatedClass::class.versionDesc()
+      desc shouldContain "Version: 1.0.0"
+      desc shouldContain "Release Date: 2026-01-01"
+    }
+
+    "versionDesc returns JSON when asJson is true" {
+      val json = AnnotatedClass::class.versionDesc(asJson = true)
+      json shouldContain "\"version\""
+      json shouldContain "1.0.0"
+      json shouldContain "\"release_date\""
+    }
+
+    "versionDesc for unannotated class returns UNKNOWN in plain text" {
+      val desc = UnannotatedClass::class.versionDesc()
+      desc shouldContain UNKNOWN
+    }
+
+    "versionDesc for unannotated class returns UNKNOWN in JSON" {
+      val json = UnannotatedClass::class.versionDesc(asJson = true)
+      json shouldContain UNKNOWN
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add ~65 new tests covering previously untested utility classes (DateUtils, HtmlUtils, HttpUtils, DslUtils, ToolCallInfo, Version)
- Extend existing tests with additional enum types (Cartesia, Deepgram, BackgroundSound, FirstMessageMode), Double/Boolean parameter types for FunctionDetails, MiscUtils edge cases, and valid-secret routing verification
- All 250 tests pass, lint clean

## Test plan
- [x] `./gradlew test` — all tests pass (250 total)
- [x] `./gradlew lintKotlin` — no lint issues
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)