### PR TITLE
Bump version from 1.5.0 to 1.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with [Vapi.ai](https://vapi.ai). It provides
 type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-**Version:** 1.5.0 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
+**Version:** 1.6.0 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
 **JVM Target:** 17
 
 Key dependency versions are managed in `gradle/libs.versions.toml`.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.5.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.0")
 
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.5.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ allprojects {
     apply {
         plugin(repoLib)
     }
-    extra["versionStr"] = "1.5.0"
+    extra["versionStr"] = "1.6.0"
     extra["releaseDate"] = LocalDate.now().format(formatter)
     group = "com.github.vapi4k.vapi4k"
     version = versionStr

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with Vapi.ai. It provides type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.5.0.
+Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.6.0.
 
 Key dependency versions: Kotlin 2.3.10, Ktor 3.4.1, Kotlinx Serialization 1.10.0, Exposed 1.1.1, Kotest 6.0.0.M4.
 
@@ -34,9 +34,9 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.5.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.0")
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.5.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.0")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Bump project version from 1.5.0 to 1.6.0 in `build.gradle.kts`
- Update version references in `README.md`, `CLAUDE.md`, and `llms.txt`

## Test plan
- [ ] Verify `./gradlew build` completes successfully
- [ ] Confirm version string appears correctly in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)