### PR TITLE
Add high-priority enum values from Vapi API spec

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/DeepgramModelType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/DeepgramModelType.kt
@@ -36,6 +36,10 @@ enum class DeepgramModelType(
   NOVA_2_DRIVETHRU("nova-2-drivethru"),
   NOVA_2_AUTOMOTIVE("nova-2-automotive"),
 
+  NOVA_3("nova-3"),
+  NOVA_3_GENERAL("nova-3-general"),
+  NOVA_3_MEDICAL("nova-3-medical"),
+
   NOVA("nova"),
   NOVA_GENERAL("nova-general"),
   NOVA_PHONECALL("nova-phonecall"),
@@ -55,6 +59,9 @@ enum class DeepgramModelType(
   BASE_CONVERSATIONAL_AI("base-conversationalai"),
   BASE_VOICEMAIL("base-voicemail"),
   BASE_VIDEO("base-video"),
+
+  FLUX_GENERAL_EN("flux-general-en"),
+  WHISPER("whisper"),
 
   UNSPECIFIED(UNSPECIFIED_DEFAULT),
   ;

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/TranscriberType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/TranscriberType.kt
@@ -16,6 +16,7 @@
 
 package com.vapi4k.api.transcriber
 
+import com.vapi4k.common.Constants.UNSPECIFIED_DEFAULT
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind.STRING
@@ -40,6 +41,12 @@ enum class TranscriberType(
   SONIOX("soniox"),
   SPEECHMATICS("speechmatics"),
   TALKSCRIBER("talkscriber"),
+  UNSPECIFIED(UNSPECIFIED_DEFAULT),
+  ;
+
+  fun isSpecified() = this != UNSPECIFIED
+
+  fun isNotSpecified() = this == UNSPECIFIED
 }
 
 object TranscriberTypeSerializer : KSerializer<TranscriberType> {

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/TranscriberType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/TranscriberType.kt
@@ -28,8 +28,17 @@ import kotlinx.serialization.encoding.Encoder
 enum class TranscriberType(
   val desc: String,
 ) {
+  ASSEMBLY_AI("assembly-ai"),
+  AZURE("azure"),
+  CARTESIA("cartesia"),
+  CUSTOM_TRANSCRIBER("custom-transcriber"),
   DEEPGRAM("deepgram"),
+  ELEVEN_LABS("11labs"),
   GLADIA("gladia"),
+  GOOGLE("google"),
+  OPEN_AI("openai"),
+  SONIOX("soniox"),
+  SPEECHMATICS("speechmatics"),
   TALKSCRIBER("talkscriber"),
 }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/VoiceProviderType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/VoiceProviderType.kt
@@ -31,13 +31,23 @@ enum class VoiceProviderType(
 ) {
   AZURE("azure"),
   CARTESIA("cartesia"),
+  CUSTOM_VOICE("custom-voice"),
   DEEPGRAM("deepgram"),
   ELEVEN_LABS("11labs"),
+  HUME("hume"),
+  INWORLD("inworld"),
   LMNT("lmnt"),
+  MINIMAX("minimax"),
   NEETS("neets"),
+  NEUPHONIC("neuphonic"),
   OPEN_AI("openai"),
   PLAY_HT("playht"),
   RIME_AI("rime-ai"),
+  SESAME("sesame"),
+  SMALLEST_AI("smallest-ai"),
+  TAVUS("tavus"),
+  VAPI("vapi"),
+  WELLSAID("wellsaid"),
   UNSPECIFIED(UNSPECIFIED_DEFAULT),
   ;
 


### PR DESCRIPTION
## Summary
- **DeepgramModelType**: Added 5 new models — nova-3 family, flux-general-en, whisper
- **VoiceProviderType**: Added 10 new providers — custom-voice, hume, inworld, minimax, neuphonic, sesame, smallest-ai, tavus, vapi, wellsaid (kept `neets` for backward compatibility)
- **TranscriberType**: Added 9 new providers — assembly-ai, azure, cartesia, custom-transcriber, 11labs, google, openai, soniox, speechmatics

All values sourced from the live Vapi OpenAPI spec (`https://api.vapi.ai/api-json`).

Resolves EO-215, EO-216, EO-217

## Test plan
- [x] `./gradlew :vapi4k-core:compileKotlin` passes
- [x] `./gradlew :vapi4k-core:test` — all tests pass
- [ ] Verify new enum values match wire format in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)