### PR TITLE
Add low-priority enum values from Vapi API spec

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/GladiaModelType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/transcriber/GladiaModelType.kt
@@ -25,6 +25,7 @@ enum class GladiaModelType(
 ) {
   FAST("fast"),
   ACCURATE("accurate"),
+  SOLARIA_1("solaria-1"),
   UNSPECIFIED(UNSPECIFIED_DEFAULT),
   ;
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/CartesiaVoiceLanguageType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/CartesiaVoiceLanguageType.kt
@@ -57,6 +57,7 @@ enum class CartesiaVoiceLanguageType(
   MARATHI("mr"),
   NORWEGIAN("no"),
   POLISH("pl"),
+  PUNJABI("pa"),
   PORTUGUESE("pt"),
   ROMANIAN("ro"),
   RUSSIAN("ru"),


### PR DESCRIPTION
## Summary
- **CartesiaVoiceLanguageType**: Added `PUNJABI("pa")`
- **GladiaModelType**: Added `SOLARIA_1("solaria-1")`

The other two low-priority issues (EO-220: `es-419` in DeepgramLanguageType, EO-221: `mistv2` in RimeAIVoiceModelType) were already present in the codebase.

Resolves EO-218, EO-219, EO-220, EO-221

## Test plan
- [x] `./gradlew :vapi4k-core:test` — all tests pass
- [x] Verified PunctuationType, DeepgramLanguageType, RimeAIVoiceModelType already in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)