### PR TITLE
Add new AssistantTransferMode values from Vapi API spec

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantTransferMode.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantTransferMode.kt
@@ -29,8 +29,10 @@ import kotlinx.serialization.encoding.Encoder
 enum class AssistantTransferMode(
   val desc: String,
 ) {
+  DELETE_HISTORY("delete-history"),
   ROLLING_HISTORY("rolling-history"),
   SWAP_SYSTEM_MESSAGE_IN_HISTORY("swap-system-message-in-history"),
+  SWAP_SYSTEM_MESSAGE_IN_HISTORY_AND_REMOVE_TRANSFER_TOOL_MESSAGES("swap-system-message-in-history-and-remove-transfer-tool-messages"),
   UNSPECIFIED(UNSPECIFIED_DEFAULT),
 }
 


### PR DESCRIPTION
## Summary
- Added `DELETE_HISTORY("delete-history")` — wipes conversation history on transfer
- Added `SWAP_SYSTEM_MESSAGE_IN_HISTORY_AND_REMOVE_TRANSFER_TOOL_MESSAGES(...)` — swaps system message and strips transfer tool call messages from context

Both values are from `TransferDestinationAssistant.transferMode` in the Vapi OpenAPI spec.

## Test plan
- [x] `./gradlew :vapi4k-core:test` — all tests pass
- [x] Values verified against `TransferDestinationAssistant.transferMode` schema in live spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)