### PR TITLE
Bump version from 1.6.0 to 1.6.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with [Vapi.ai](https://vapi.ai). It provides
 type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-**Version:** 1.6.0 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
+**Version:** 1.6.1 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
 **JVM Target:** 17
 
 Key dependency versions are managed in `gradle/libs.versions.toml`.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.1")
 
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ allprojects {
     apply {
         plugin(repoLib)
     }
-    extra["versionStr"] = "1.6.0"
+    extra["versionStr"] = "1.6.1"
     extra["releaseDate"] = LocalDate.now().format(formatter)
     group = "com.github.vapi4k.vapi4k"
     version = versionStr

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with Vapi.ai. It provides type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.6.0.
+Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.6.1.
 
 Key dependency versions: Kotlin 2.3.10, Ktor 3.4.1, Kotlinx Serialization 1.10.0, Exposed 1.1.1, Kotest 6.0.0.M4.
 
@@ -34,9 +34,9 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.1")
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.0")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.1")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Version bump 1.6.0 → 1.6.1 in `build.gradle.kts`, `README.md`, `CLAUDE.md`, and `llms.txt`
- Reflects enum sync work from PRs #29–#33

## Test plan
- [x] Version string updated in all 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)