### PR TITLE
Fix lint line-length violation in AssistantTransferMode

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantTransferMode.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantTransferMode.kt
@@ -32,7 +32,9 @@ enum class AssistantTransferMode(
   DELETE_HISTORY("delete-history"),
   ROLLING_HISTORY("rolling-history"),
   SWAP_SYSTEM_MESSAGE_IN_HISTORY("swap-system-message-in-history"),
-  SWAP_SYSTEM_MESSAGE_IN_HISTORY_AND_REMOVE_TRANSFER_TOOL_MESSAGES("swap-system-message-in-history-and-remove-transfer-tool-messages"),
+  SWAP_SYSTEM_MESSAGE_IN_HISTORY_AND_REMOVE_TRANSFER_TOOL_MESSAGES(
+    "swap-system-message-in-history-and-remove-transfer-tool-messages",
+  ),
   UNSPECIFIED(UNSPECIFIED_DEFAULT),
 }
 


### PR DESCRIPTION
## Summary
- Wrap long `SWAP_SYSTEM_MESSAGE_IN_HISTORY_AND_REMOVE_TRANSFER_TOOL_MESSAGES` enum entry onto multiple lines to fix ktlint `max-line-length` (120 char) and `argument-list-wrapping` violations

## Test plan
- [x] `./gradlew lintKotlin` passes
- [ ] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)