### PR TITLE
Replace StepDestination with Dynamic and Squad destinations

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantDestination.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/AssistantDestination.kt
@@ -16,14 +16,14 @@
 
 package com.vapi4k.api.destination
 
-import com.vapi4k.dsl.destination.CommonDestination
+import com.vapi4k.dsl.destination.TransferDestination
 import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 
 /**
 This is the assistant destination you'd like the call to be transferred to.
  */
 @Vapi4KDslMarker
-interface AssistantDestination : CommonDestination {
+interface AssistantDestination : TransferDestination {
   /**
   This is the assistant to transfer the call to.
    */

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/DestinationType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/DestinationType.kt
@@ -29,9 +29,10 @@ enum class DestinationType(
   val desc: String,
 ) {
   ASSISTANT("assistant"),
+  DYNAMIC("dynamic"),
   NUMBER("number"),
   SIP("sip"),
-  STEP("step"),
+  SQUAD("squad"),
 }
 
 object DestinationTypeSerializer : KSerializer<DestinationType> {

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/DynamicDestination.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/DynamicDestination.kt
@@ -14,20 +14,13 @@
  *
  */
 
-package com.vapi4k.dtos.api.destination
+package com.vapi4k.api.destination
 
-import com.vapi4k.api.destination.DestinationType
-import com.vapi4k.api.destination.StepDestination
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.Serializable
+import com.vapi4k.dsl.destination.CommonDestination
+import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 
-@Serializable
-data class StepDestinationDto(
-  override var message: String = "",
-  override var description: String = "",
-  override var stepName: String = "",
-) : CommonDestinationDto,
-  StepDestination {
-  @EncodeDefault
-  val type: DestinationType = DestinationType.NUMBER
-}
+/**
+This is the dynamic destination where the handoff destination is determined at runtime via a webhook.
+ */
+@Vapi4KDslMarker
+interface DynamicDestination : CommonDestination

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/NumberDestination.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/NumberDestination.kt
@@ -16,11 +16,11 @@
 
 package com.vapi4k.api.destination
 
-import com.vapi4k.dsl.destination.CommonDestination
+import com.vapi4k.dsl.destination.TransferDestination
 import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 
 @Vapi4KDslMarker
-interface NumberDestination : CommonDestination {
+interface NumberDestination : TransferDestination {
   /**
   This is the phone number to transfer the call to.
    */

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/SquadDestination.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/destination/SquadDestination.kt
@@ -14,17 +14,24 @@
  *
  */
 
-package com.vapi4k.dsl.destination
+package com.vapi4k.api.destination
 
-import com.vapi4k.api.destination.StepDestination
-import com.vapi4k.dtos.api.destination.StepDestinationDto
+import com.vapi4k.dsl.destination.CommonDestination
+import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 
-class StepDestinationImpl internal constructor(
-  private val dto: StepDestinationDto,
-) : StepDestination by dto {
-  fun checkForRequiredFields() {
-    if (dto.stepName.isEmpty()) {
-      error("stepDestination{} requires a stepName value")
-    }
-  }
+/**
+This is the squad destination where the call is transferred to a multi-agent squad.
+ */
+@Vapi4KDslMarker
+interface SquadDestination : CommonDestination {
+  /**
+  This is the squad id to transfer the call to.
+   */
+  var squadId: String
+
+  /**
+  This is the name of the entry assistant to start with when handing off to the squad.
+  If not provided, the first assistant in the squad is used.
+   */
+  var entryAssistantName: String
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/tools/TransferDestinationResponse.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/tools/TransferDestinationResponse.kt
@@ -17,9 +17,10 @@
 package com.vapi4k.api.tools
 
 import com.vapi4k.api.destination.AssistantDestination
+import com.vapi4k.api.destination.DynamicDestination
 import com.vapi4k.api.destination.NumberDestination
 import com.vapi4k.api.destination.SipDestination
-import com.vapi4k.api.destination.StepDestination
+import com.vapi4k.api.destination.SquadDestination
 import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
 
 /**
@@ -33,6 +34,11 @@ interface TransferDestinationResponse {
   fun assistantDestination(block: AssistantDestination.() -> Unit)
 
   /**
+  Transfers the call to a dynamically determined destination via a webhook.
+   */
+  fun dynamicDestination(block: DynamicDestination.() -> Unit)
+
+  /**
   Transfers the call to a number.
    */
   fun numberDestination(block: NumberDestination.() -> Unit)
@@ -43,7 +49,7 @@ interface TransferDestinationResponse {
   fun sipDestination(block: SipDestination.() -> Unit)
 
   /**
-  Transfers the call to a step.
+  Transfers the call to a multi-agent squad.
    */
-  fun stepDestination(block: StepDestination.() -> Unit)
+  fun squadDestination(block: SquadDestination.() -> Unit)
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/CommonDestination.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/CommonDestination.kt
@@ -18,15 +18,17 @@ package com.vapi4k.dsl.destination
 
 interface CommonDestination {
   /**
+  This is the description of the destination, used by the AI to choose when and how to transfer the call.
+   */
+  var description: String
+}
+
+interface TransferDestination : CommonDestination {
+  /**
   <p>This is the message to say before transferring the call to the destination.
   <br>If this is not provided and transfer tool messages is not provided, default is "Transferring the call now".
   <br>If set to "", nothing is spoken. This is useful when you want to silently transfer. This is especially useful when transferring between assistants in a squad. In this scenario, you likely also want to set <code>assistant.firstMessageMode=assistant-speaks-first-with-model-generated-message</code> for the destination assistant.
   </p>
    */
   var message: String
-
-  /**
-  This is the description of the destination, used by the AI to choose when and how to transfer the call.
-   */
-  var description: String
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/DynamicDestinationImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/DynamicDestinationImpl.kt
@@ -14,15 +14,11 @@
  *
  */
 
-package com.vapi4k.api.destination
+package com.vapi4k.dsl.destination
 
-import com.vapi4k.dsl.destination.TransferDestination
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
+import com.vapi4k.api.destination.DynamicDestination
+import com.vapi4k.dtos.api.destination.DynamicDestinationDto
 
-@Vapi4KDslMarker
-interface SipDestination : TransferDestination {
-  /**
-  This is the SIP URI to transfer the call to.
-   */
-  var sipUri: String
-}
+class DynamicDestinationImpl internal constructor(
+  private val dto: DynamicDestinationDto,
+) : DynamicDestination by dto

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/SquadDestinationImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/destination/SquadDestinationImpl.kt
@@ -14,13 +14,17 @@
  *
  */
 
-package com.vapi4k.dtos.api.destination
+package com.vapi4k.dsl.destination
 
-import kotlinx.serialization.Serializable
+import com.vapi4k.api.destination.SquadDestination
+import com.vapi4k.dtos.api.destination.SquadDestinationDto
 
-// Not used for now
-@Serializable
-abstract class AbstractDestinationDto {
-  var message: String = ""
-  var description: String = ""
+class SquadDestinationImpl internal constructor(
+  private val dto: SquadDestinationDto,
+) : SquadDestination by dto {
+  fun checkForRequiredFields() {
+    if (dto.squadId.isEmpty()) {
+      error("squadDestination{} requires a squadId value")
+    }
+  }
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/tools/TransferDestinationImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/tools/TransferDestinationImpl.kt
@@ -17,19 +17,22 @@
 package com.vapi4k.dsl.tools
 
 import com.vapi4k.api.destination.AssistantDestination
+import com.vapi4k.api.destination.DynamicDestination
 import com.vapi4k.api.destination.NumberDestination
 import com.vapi4k.api.destination.SipDestination
-import com.vapi4k.api.destination.StepDestination
+import com.vapi4k.api.destination.SquadDestination
 import com.vapi4k.api.tools.TransferDestinationResponse
 import com.vapi4k.common.DuplicateInvokeChecker
 import com.vapi4k.dsl.destination.AssistantDestinationImpl
+import com.vapi4k.dsl.destination.DynamicDestinationImpl
 import com.vapi4k.dsl.destination.NumberDestinationImpl
 import com.vapi4k.dsl.destination.SipDestinationImpl
-import com.vapi4k.dsl.destination.StepDestinationImpl
+import com.vapi4k.dsl.destination.SquadDestinationImpl
 import com.vapi4k.dtos.api.destination.AssistantDestinationDto
+import com.vapi4k.dtos.api.destination.DynamicDestinationDto
 import com.vapi4k.dtos.api.destination.NumberDestinationDto
 import com.vapi4k.dtos.api.destination.SipDestinationDto
-import com.vapi4k.dtos.api.destination.StepDestinationDto
+import com.vapi4k.dtos.api.destination.SquadDestinationDto
 import com.vapi4k.dtos.tools.TransferMessageResponseDto
 
 class TransferDestinationImpl internal constructor(
@@ -44,6 +47,12 @@ class TransferDestinationImpl internal constructor(
     AssistantDestinationImpl(assistantDto).apply(block).checkForRequiredFields()
   }
 
+  override fun dynamicDestination(block: DynamicDestination.() -> Unit) {
+    duplicateChecker.check("dynamicDestination{} already called in $callerName{}")
+    val dynamicDto = DynamicDestinationDto().also { dto.messageResponse.destination = it }
+    DynamicDestinationImpl(dynamicDto).apply(block)
+  }
+
   override fun numberDestination(block: NumberDestination.() -> Unit) {
     duplicateChecker.check("numberDestination{} already called in $callerName{}")
     val numDto = NumberDestinationDto().also { dto.messageResponse.destination = it }
@@ -56,9 +65,9 @@ class TransferDestinationImpl internal constructor(
     SipDestinationImpl(sipDto).apply(block).checkForRequiredFields()
   }
 
-  override fun stepDestination(block: StepDestination.() -> Unit) {
-    duplicateChecker.check("stepDestination{} already called in $callerName{}")
-    val stepDto = StepDestinationDto().also { dto.messageResponse.destination = it }
-    StepDestinationImpl(stepDto).apply(block).checkForRequiredFields()
+  override fun squadDestination(block: SquadDestination.() -> Unit) {
+    duplicateChecker.check("squadDestination{} already called in $callerName{}")
+    val squadDto = SquadDestinationDto().also { dto.messageResponse.destination = it }
+    SquadDestinationImpl(squadDto).apply(block).checkForRequiredFields()
   }
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/tools/TransferToolImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/tools/TransferToolImpl.kt
@@ -17,19 +17,22 @@
 package com.vapi4k.dsl.tools
 
 import com.vapi4k.api.destination.AssistantDestination
+import com.vapi4k.api.destination.DynamicDestination
 import com.vapi4k.api.destination.NumberDestination
 import com.vapi4k.api.destination.SipDestination
-import com.vapi4k.api.destination.StepDestination
+import com.vapi4k.api.destination.SquadDestination
 import com.vapi4k.api.tools.TransferDestinationResponse
 import com.vapi4k.api.tools.TransferTool
 import com.vapi4k.dsl.destination.AssistantDestinationImpl
+import com.vapi4k.dsl.destination.DynamicDestinationImpl
 import com.vapi4k.dsl.destination.NumberDestinationImpl
 import com.vapi4k.dsl.destination.SipDestinationImpl
-import com.vapi4k.dsl.destination.StepDestinationImpl
+import com.vapi4k.dsl.destination.SquadDestinationImpl
 import com.vapi4k.dtos.api.destination.AssistantDestinationDto
+import com.vapi4k.dtos.api.destination.DynamicDestinationDto
 import com.vapi4k.dtos.api.destination.NumberDestinationDto
 import com.vapi4k.dtos.api.destination.SipDestinationDto
-import com.vapi4k.dtos.api.destination.StepDestinationDto
+import com.vapi4k.dtos.api.destination.SquadDestinationDto
 import com.vapi4k.dtos.tools.ToolDto
 
 class TransferToolImpl internal constructor(
@@ -43,6 +46,11 @@ class TransferToolImpl internal constructor(
     AssistantDestinationImpl(assistantDto).apply(block).checkForRequiredFields()
   }
 
+  override fun dynamicDestination(block: DynamicDestination.() -> Unit) {
+    val dynamicDto = DynamicDestinationDto().also { dto.destinations += it }
+    DynamicDestinationImpl(dynamicDto).apply(block)
+  }
+
   override fun numberDestination(block: NumberDestination.() -> Unit) {
     val numDto = NumberDestinationDto().also { dto.destinations += it }
     NumberDestinationImpl(numDto).apply(block).checkForRequiredFields()
@@ -53,8 +61,8 @@ class TransferToolImpl internal constructor(
     SipDestinationImpl(sipDto).apply(block).checkForRequiredFields()
   }
 
-  override fun stepDestination(block: StepDestination.() -> Unit) {
-    val stepDto = StepDestinationDto().also { dto.destinations += it }
-    StepDestinationImpl(stepDto).apply(block).checkForRequiredFields()
+  override fun squadDestination(block: SquadDestination.() -> Unit) {
+    val squadDto = SquadDestinationDto().also { dto.destinations += it }
+    SquadDestinationImpl(squadDto).apply(block).checkForRequiredFields()
   }
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/CommonDestinationDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/CommonDestinationDto.kt
@@ -35,8 +35,10 @@ object DestinationSerializer : KSerializer<CommonDestinationDto> {
   ) {
     when (value) {
       is AssistantDestinationDto -> encoder.encodeSerializableValue(AssistantDestinationDto.serializer(), value)
+      is DynamicDestinationDto -> encoder.encodeSerializableValue(DynamicDestinationDto.serializer(), value)
       is NumberDestinationDto -> encoder.encodeSerializableValue(NumberDestinationDto.serializer(), value)
       is SipDestinationDto -> encoder.encodeSerializableValue(SipDestinationDto.serializer(), value)
+      is SquadDestinationDto -> encoder.encodeSerializableValue(SquadDestinationDto.serializer(), value)
       else -> error("Invalid destination provider: ${value::class.simpleName}")
     }
   }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/DynamicDestinationDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/DynamicDestinationDto.kt
@@ -14,13 +14,18 @@
  *
  */
 
-package com.vapi4k.api.destination
+package com.vapi4k.dtos.api.destination
 
-import com.vapi4k.dsl.destination.CommonDestination
+import com.vapi4k.api.destination.DestinationType
+import com.vapi4k.api.destination.DynamicDestination
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.Serializable
 
-interface StepDestination : CommonDestination {
-  /**
-  This is the step to transfer to.
-   */
-  var stepName: String
+@Serializable
+data class DynamicDestinationDto(
+  override var description: String = "",
+) : CommonDestinationDto,
+  DynamicDestination {
+  @EncodeDefault
+  val type: DestinationType = DestinationType.DYNAMIC
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/SquadDestinationDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/api/destination/SquadDestinationDto.kt
@@ -14,15 +14,20 @@
  *
  */
 
-package com.vapi4k.api.destination
+package com.vapi4k.dtos.api.destination
 
-import com.vapi4k.dsl.destination.TransferDestination
-import com.vapi4k.dsl.vapi4k.Vapi4KDslMarker
+import com.vapi4k.api.destination.DestinationType
+import com.vapi4k.api.destination.SquadDestination
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.Serializable
 
-@Vapi4KDslMarker
-interface SipDestination : TransferDestination {
-  /**
-  This is the SIP URI to transfer the call to.
-   */
-  var sipUri: String
+@Serializable
+data class SquadDestinationDto(
+  override var description: String = "",
+  override var squadId: String = "",
+  override var entryAssistantName: String = "",
+) : CommonDestinationDto,
+  SquadDestination {
+  @EncodeDefault
+  val type: DestinationType = DestinationType.SQUAD
 }


### PR DESCRIPTION
## Summary
- Remove `StepDestination` (no longer in Vapi OpenAPI spec) and add `DynamicDestination` (handoff via webhook) and `SquadDestination` (handoff to multi-agent squad)
- Refactor destination type hierarchy: `CommonDestination` (description only) → `TransferDestination` (adds message) for transfer types; handoff types extend `CommonDestination` directly without `message`
- Remove unused `AbstractDestinationDto` dead code

## Test plan
- [x] All existing tests pass (`./gradlew test`)
- [x] Kotlin lint passes (`./gradlew lintKotlin`)
- [x] Compilation succeeds across all modules
- [ ] Verify `dynamicDestination{}` and `squadDestination{}` DSL builders work in integration tests
- [ ] Confirm serialized JSON matches Vapi API expectations for new destination types

🤖 Generated with [Claude Code](https://claude.com/claude-code)