### PR TITLE
Rename PunctuationType to PunctuationBoundaryType to mirror Vapi API

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/PunctuationBoundaryType.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/voice/PunctuationBoundaryType.kt
@@ -24,8 +24,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-@Serializable(with = PunctuationTypeSerializer::class)
-enum class PunctuationType(
+@Serializable(with = PunctuationBoundaryTypeSerializer::class)
+enum class PunctuationBoundaryType(
   val desc: String,
 ) {
   ARABIC_COMMA('\u060C'.toString()),
@@ -45,13 +45,14 @@ enum class PunctuationType(
   VERTICAL_BAR("|"),
 }
 
-object PunctuationTypeSerializer : KSerializer<PunctuationType> {
-  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("PunctuationType", STRING)
+object PunctuationBoundaryTypeSerializer : KSerializer<PunctuationBoundaryType> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("PunctuationBoundaryType", STRING)
 
   override fun serialize(
     encoder: Encoder,
-    value: PunctuationType,
+    value: PunctuationBoundaryType,
   ) = encoder.encodeString(value.desc)
 
-  override fun deserialize(decoder: Decoder) = PunctuationType.entries.first { it.desc == decoder.decodeString() }
+  override fun deserialize(decoder: Decoder) =
+    PunctuationBoundaryType.entries.first { it.desc == decoder.decodeString() }
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanProperties.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/voice/ChunkPlanProperties.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.dsl.voice
 
-import com.vapi4k.api.voice.PunctuationType
+import com.vapi4k.api.voice.PunctuationBoundaryType
 
 interface ChunkPlanProperties {
   /**
@@ -50,5 +50,5 @@ interface ChunkPlanProperties {
   chunks, so it can sound less disjointed across chunks. Eg. ['.'].
   </p>
    */
-  val punctuationBoundaries: MutableSet<PunctuationType>
+  val punctuationBoundaries: MutableSet<PunctuationBoundaryType>
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ChunkPlanDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/voice/ChunkPlanDto.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.dtos.voice
 
-import com.vapi4k.api.voice.PunctuationType
+import com.vapi4k.api.voice.PunctuationBoundaryType
 import com.vapi4k.dsl.voice.ChunkPlanProperties
 import kotlinx.serialization.Serializable
 
@@ -24,6 +24,6 @@ import kotlinx.serialization.Serializable
 data class ChunkPlanDto(
   override var enabled: Boolean? = null,
   override var minCharacters: Int = -1,
-  override val punctuationBoundaries: MutableSet<PunctuationType> = mutableSetOf(),
+  override val punctuationBoundaries: MutableSet<PunctuationBoundaryType> = mutableSetOf(),
   val formatPlan: FormatPlanDto = FormatPlanDto(),
 ) : ChunkPlanProperties

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
@@ -28,7 +28,7 @@ import com.vapi4k.api.voice.CartesiaVoiceLanguageType
 import com.vapi4k.api.voice.CartesiaVoiceModelType
 import com.vapi4k.api.voice.PlayHTVoiceEmotionType
 import com.vapi4k.api.voice.PlayHTVoiceIdType
-import com.vapi4k.api.voice.PunctuationType
+import com.vapi4k.api.voice.PunctuationBoundaryType
 import com.vapi4k.utils.assistantResponse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -280,8 +280,8 @@ class VoiceTest : StringSpec() {
                     chunkPlan {
                       enabled = true
                       minCharacters = 40
-                      punctuationBoundaries += PunctuationType.PERIOD
-                      punctuationBoundaries += PunctuationType.COMMA
+                      punctuationBoundaries += PunctuationBoundaryType.PERIOD
+                      punctuationBoundaries += PunctuationBoundaryType.COMMA
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- Rename `PunctuationType` → `PunctuationBoundaryType` to match the Vapi API field name `ChunkPlan.punctuationBoundaries`
- Rename serializer `PunctuationTypeSerializer` → `PunctuationBoundaryTypeSerializer`
- Update all references in ChunkPlanProperties, ChunkPlanDto, and VoiceTest

## Test plan
- [x] `./gradlew build` passes with all tests green
- [x] No remaining references to old `PunctuationType` name
- [x] Verified enum values match Vapi OpenAPI spec (all 15 punctuation boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)