### PR TITLE
Migrate publishing from JitPack to Maven Central (#44)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,24 @@
 .gradle
 build/
+out/
 .kotlin
 TTD.txt
 secrets
 http-client.private.env.json
 vapi2.conf
-
 .DS_Store
 
 .run/
 secrets/
 .claude/worktrees
 
-src/test/resources/application.conf
-
 !gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
 
 ### IntelliJ IDEA ###
 .idea
 *.iws
 *.iml
 *.ipr
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
 
 ### VS Code ###
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,227 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.6.2] - 2026-04-01
+
+### Changed
+
+- Bump dependencies to latest versions (#43)
+
+## [1.6.1] - 2026-03-19
+
+### Added
+
+- Testcontainers integration tests for vapi4k-dbms (#35)
+- 6 new model providers synced with Vapi API spec (#40)
+- New transfer mode values from Vapi API spec (#32)
+- Punjabi language support for Cartesia and solaria-1 model for Gladia (#31)
+- High-priority enum values from Vapi API spec (#30)
+- New enum values for message types and server requests (#28)
+
+### Changed
+
+- Rename `PunctuationType` to `PunctuationBoundaryType` to mirror Vapi API (#39)
+- Replace `StepDestination` with `DynamicDestination` and `SquadDestination` from Vapi API spec (#37)
+- Update provider counts in README and CLAUDE.md (#33)
+- Add Vapi API spec reference and provider patterns to CLAUDE.md (#41)
+
+### Fixed
+
+- `SuccessEvaluationRubricType` case mismatch with Vapi API spec (#42)
+- Lint line-length violation in `AssistantTransferMode` enum (#36)
+
+### Removed
+
+- Neets voice provider no longer in Vapi API spec (#38)
+- `TOOL_CALLS_RESULTS` enum value not in Vapi API spec (#29)
+
+## [1.6.0] - 2026-03-17
+
+### Added
+
+- Test coverage for utilities, enums, tools, and routing (#26)
+- Test coverage for foundation utilities, value classes, and providers (#23)
+- `/vapi-enum-diff` command to compare enums against Vapi OpenAPI spec (#18)
+
+### Changed
+
+- Migrate test framework from JUnit 5 + Kluent to Kotest 6 StringSpec (#25)
+- Clean up test assertion style and reduce reflection boilerplate (#24)
+- Restructure voice DTOs to nest chunkPlan/formatPlan matching Vapi API wire format (#21)
+- Sync language enums with Vapi OpenAPI spec (#20)
+- Sync model enums with Vapi OpenAPI spec (#19)
+- Bump dependency versions: config, micrometer, utils, and Gradle wrapper (#22)
+
+### Removed
+
+- OpenSpec framework (#17)
+
+## [1.5.0] - 2026-03-03
+
+### Changed
+
+- Extract version variable in Makefile to avoid hardcoded duplication
+- Add build trigger and view commands to Makefile for JitPack integration
+- Disable configuration cache for `dependencyUpdates` command in Makefile
+
+## [1.4.0] - 2026-02-18
+
+### Changed
+
+- Update group ID in build configuration and documentation for consistency
+- Update gradle-plugins version to 1.0.3 and adjust import path for `BuildConfig`
+
+## [1.3.7] - 2026-02-09
+
+### Changed
+
+- Update Dokka configuration and add packages.md for documentation
+- Refactor build configuration to use Kotlin serialization plugin and update dependency versions
+- Bump dependencies
+
+### Fixed
+
+- Documentation references for `VoicemailTool` in `AssistantFunctions.kt` and `VoicemailDetection.kt`
+
+## [1.3.6] - 2026-01-29
+
+### Changed
+
+- Version bump and documentation updates
+
+## [1.3.5] - 2026-01-29
+
+### Changed
+
+- Update verbose logging variable names for clarity (#14)
+
+## [1.3.4] - 2026-01-29
+
+### Added
+
+- Build-tests target in Makefile for compiling test Kotlin sources
+
+### Changed
+
+- Enhance JSON handling with verbose logging (#13)
+- Upgrade Gradle to version 9.3.0 and update dependencies
+- Refactor `ChildSerializer` to remove unnecessary private modifier and simplify response handling in TestUtils
+- Update enums (#11)
+
+## [1.3.3] - 2026-01-21
+
+### Changed
+
+- Version bump release (#12)
+
+## [1.3.2] - 2025-08-18
+
+### Changed
+
+- Update JSON utility method usages (#10)
+
+## [1.3.1] - 2025-08-18
+
+### Changed
+
+- Version bump release (#9)
+
+## [1.3.0] - 2025-06-26
+
+### Changed
+
+- Version bump release (#8)
+
+## [1.2.4] - 2025-02-16
+
+### Fixed
+
+- KDocs generation (#7)
+
+## [1.2.3] - 2025-02-08
+
+### Changed
+
+- Version bump release (#6)
+
+## [1.2.2] - 2024-12-19
+
+### Changed
+
+- Version bump release (#5)
+
+## [1.2.1] - 2024-12-11
+
+### Changed
+
+- Version bump release (#4)
+
+## [1.2.0] - 2024-11-27
+
+### Changed
+
+- Update to Kotlin 2.1.0 (#3)
+
+## [1.1.1] - 2024-11-01
+
+### Changed
+
+- Update Kotlin to 2.0.21 (#2)
+
+## [1.1.0] - 2024-10-30
+
+### Changed
+
+- Update to Ktor 3.0.0 (#1)
+- Refactor `AssistantIdSource`
+
+## [1.0.1] - 2024-10-05
+
+### Added
+
+- CodeQL, SonarQube, and Detekt CI configurations
+
+### Changed
+
+- Consolidate KDocs into a single build directory
+- Remove enums packages and consolidate classes
+- Clean up ktlint issues
+
+## [1.0.0] - 2024-10-03
+
+### Added
+
+- Initial release of Vapi4k
+- Ktor plugin and Kotlin DSL for building voice AI applications with Vapi.ai
+- Type-safe builders for assistants, tools, models, voices, and call workflows
+- Support for inbound calls, outbound calls, and web-based voice interactions
+- Service tool, manual tool, and external tool strategies
+- Admin dashboard with HTMX and Bootstrap
+- Prometheus metrics integration
+- Maven Central publishing
+
+[1.6.2]: https://github.com/vapi4k/vapi4k/compare/1.6.1...1.6.2
+[1.6.1]: https://github.com/vapi4k/vapi4k/compare/1.6.0...1.6.1
+[1.6.0]: https://github.com/vapi4k/vapi4k/compare/1.5.0...1.6.0
+[1.5.0]: https://github.com/vapi4k/vapi4k/compare/1.4.0...1.5.0
+[1.4.0]: https://github.com/vapi4k/vapi4k/compare/1.3.7...1.4.0
+[1.3.7]: https://github.com/vapi4k/vapi4k/compare/1.3.6...1.3.7
+[1.3.6]: https://github.com/vapi4k/vapi4k/compare/1.3.5...1.3.6
+[1.3.5]: https://github.com/vapi4k/vapi4k/compare/1.3.4...1.3.5
+[1.3.4]: https://github.com/vapi4k/vapi4k/compare/1.3.2...1.3.4
+[1.3.3]: https://github.com/vapi4k/vapi4k/compare/1.3.2...1.3.3
+[1.3.2]: https://github.com/vapi4k/vapi4k/compare/1.3.1...1.3.2
+[1.3.1]: https://github.com/vapi4k/vapi4k/compare/1.3.0...1.3.1
+[1.3.0]: https://github.com/vapi4k/vapi4k/compare/1.2.4...1.3.0
+[1.2.4]: https://github.com/vapi4k/vapi4k/compare/1.2.3...1.2.4
+[1.2.3]: https://github.com/vapi4k/vapi4k/compare/1.2.2...1.2.3
+[1.2.2]: https://github.com/vapi4k/vapi4k/compare/1.2.1...1.2.2
+[1.2.1]: https://github.com/vapi4k/vapi4k/compare/1.2.0...1.2.1
+[1.2.0]: https://github.com/vapi4k/vapi4k/compare/1.1.1...1.2.0
+[1.1.1]: https://github.com/vapi4k/vapi4k/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/vapi4k/vapi4k/compare/1.0.1...1.1.0
+[1.0.1]: https://github.com/vapi4k/vapi4k/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/vapi4k/vapi4k/releases/tag/1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with [Vapi.ai](https://vapi.ai). It provides
 type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-**Version:** 1.6.2 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
+**Version:** 1.7.0 (defined in root `build.gradle.kts` via `extra["versionStr"]`)
 **JVM Target:** 17
 
 Key dependency versions are managed in `gradle/libs.versions.toml`.
@@ -185,7 +185,7 @@ custom `KSerializer` — they use the standard pattern but without the sentinel 
 
 ### External JSON Utilities
 
-The codebase heavily uses `com.github.pambrose.common-utils:json-utils` (imported as `utils-json` in the version
+The codebase heavily uses `com.pambrose.common-utils:json-utils` (imported as `utils-json` in the version
 catalog). Provides `toJsonElement()`, `toJsonString()`, dot-path access (`stringValue("a.b.c")`), and more. Imported
 throughout core and tests.
 
@@ -284,5 +284,7 @@ starts a Ktor test app, posts a JSON fixture, and returns `(HttpResponse, JsonEl
 
 ## Publishing
 
-Published to JitPack: group `com.github.vapi4k.vapi4k`, artifacts `vapi4k-core`, `vapi4k-dbms`, `vapi4k-utils`.
-All modules include sources JAR. Template repo: [vapi4k-template](https://github.com/vapi4k/vapi4k-template).
+Published to Maven Central: group `com.vapi4k`, artifacts `vapi4k-core`, `vapi4k-dbms`, `vapi4k-utils`.
+All modules include sources JAR and Dokka javadoc JAR. Uses the
+[Vanniktech Maven Publish](https://github.com/vanniktech/gradle-maven-publish-plugin) plugin with automatic release.
+Template repo: [vapi4k-template](https://github.com/vapi4k/vapi4k-template).

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,6 @@ tests:
 jar:
 	./gradlew uberJar
 
-dist:
-	./gradlew installDist
-
 stage:
 	./gradlew stage
 
@@ -41,30 +38,33 @@ versioncheck:
 buildconfig:
 	./gradlew generateBuildConfig
 
-kdocs:
-	./gradlew :dokkaGenerate
-
-trigger-jitpack:
-	until curl -s "https://jitpack.io/com/github/vapi4k/vapi4k/$(VERSION)/build.log" | grep -qv "not found"; do \
-		echo "Waiting for JitPack..."; \
-		sleep 10; \
-	done
-
-view-jitpack:
-	curl -s "https://jitpack.io/com/github/vapi4k/vapi4k/$(VERSION)/build.log"
-	curl -s "https://jitpack.io/api/builds/com.github.vapi4k/vapi4k/$(VERSION)" | jq
-
 refresh:
 	./gradlew --refresh-dependencies dependencyUpdates
-
-mddocs:
-	./gradlew dokkaGfm
 
 updatedocs:
 	./bin/update-docs.sh
 
-publish:
+mddocs:
+	./gradlew dokkaGfm
+
+kdocs:
+	./gradlew :dokkaGenerate
+
+publish-local:
 	./gradlew publishToMavenLocal
+
+publish-local-snapshot:
+	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
+
+GPG_ENV = \
+	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
+
+publish-snapshot:
+	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
+
+publish-maven-central:
+	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
 upgrade-wrapper:
 	./gradlew wrapper --gradle-version=9.4.1 --distribution-type=bin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vapi4k
 
-[![Release](https://jitpack.io/v/vapi4k/vapi4k.svg)](https://jitpack.io/#vapi4k/vapi4k)
+[![Maven Central](https://img.shields.io/maven-central/v/com.vapi4k/vapi4k-core)](https://central.sonatype.com/namespace/com.vapi4k)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=vapi4k_vapi4k&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=vapi4k_vapi4k)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=vapi4k_vapi4k&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=vapi4k_vapi4k)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2ec91457b7814a73a7ac70b9e1290f1e)](https://app.codacy.com/gh/vapi4k/vapi4k/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
@@ -24,18 +24,14 @@ that makes it easy to define, deploy, and maintain [Vapi](https://vapi.ai) voice
 
 ## Installation
 
-Add the JitPack repository and dependency to your `build.gradle.kts`:
+Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
-repositories {
-  maven("https://jitpack.io")
-}
-
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.2")
+  implementation("com.vapi4k:vapi4k-core:1.7.0")
 
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.2")
+  implementation("com.vapi4k:vapi4k-dbms:1.7.0")
 }
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,80 @@
+# Release Notes — v1.7.0
+
+## Highlights
+
+This release migrates Vapi4k from JitPack to **Maven Central** and updates the Maven group ID. Downstream
+consumers must update their dependency declarations.
+
+## Breaking Changes
+
+### Maven coordinates changed
+
+| | Before (1.6.2) | After (1.7.0) |
+|---|---|---|
+| **Repository** | `maven("https://jitpack.io")` | `mavenCentral()` |
+| **Group ID** | `com.github.vapi4k.vapi4k` | `com.vapi4k` |
+| **Example** | `com.github.vapi4k.vapi4k:vapi4k-core:1.6.2` | `com.vapi4k:vapi4k-core:1.7.0` |
+
+**Migration:** Remove the JitPack repository from your `build.gradle.kts` (Maven Central is included by default)
+and update the group ID in all dependency declarations:
+
+```kotlin
+// Before
+repositories {
+  maven("https://jitpack.io")
+}
+dependencies {
+  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.2")
+  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.2")
+}
+
+// After
+dependencies {
+  implementation("com.vapi4k:vapi4k-core:1.7.0")
+  implementation("com.vapi4k:vapi4k-dbms:1.7.0")
+}
+```
+
+## Changes
+
+### Publishing
+
+- Migrate artifact publishing from JitPack to Maven Central
+- Adopt [Vanniktech Maven Publish](https://github.com/vanniktech/gradle-maven-publish-plugin) plugin for
+  streamlined Central publishing with automatic release
+- Add GPG signing support (conditional — skipped when no signing key is provided)
+- Add POM metadata (license, developer info, SCM URLs) required by Maven Central
+
+### Build
+
+- Update `common-utils` dependency coordinates from `com.github.pambrose` to `com.pambrose` (group `2.7.1`)
+- Update `gradle-plugins` from 1.0.10 to 1.0.12
+- Remove unused Gradle plugins: `pambrose-repos`, `pambrose-snapshot`, `pambrose-testing`
+- Remove unused `ktor-client-mock` test dependency
+- Simplify `settings.gradle.kts` by removing JitPack plugin resolution strategy
+- Centralize publishing configuration in root `build.gradle.kts` (removed per-module publishing blocks)
+- Support version override via Gradle property (`-PoverrideVersion=...`) for snapshot builds
+
+### Makefile
+
+- Rename `publish` target to `publish-local`
+- Add `publish-local-snapshot`, `publish-snapshot`, and `publish-maven-central` targets
+- Remove JitPack-specific `trigger-jitpack` and `view-jitpack` targets
+- Remove `dist` target
+
+### Documentation
+
+- Update README badge from JitPack to Maven Central
+- Update installation instructions to remove JitPack repository requirement
+- Update `llms.txt` with new coordinates and version
+- Remove JitPack link from documentation references
+
+### Internal
+
+- Update all import paths from `com.github.pambrose.common` to `com.pambrose.common` across source and test files
+- Simplify `.gitignore` by removing redundant exclusion rules
+- Clean up opt-in annotations to use a loop instead of repeated calls
+
+## Full Changelog
+
+https://github.com/vapi4k/vapi4k/compare/1.6.2...1.7.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,64 +1,56 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 
 plugins {
-    `java-library`
-    `maven-publish`
-
     alias(libs.plugins.jvm) apply true
     alias(libs.plugins.dokka) apply true
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.maven.publish) apply false
 
-    alias(libs.plugins.pambrose.envvar) apply true
     alias(libs.plugins.pambrose.stable.versions) apply true
     alias(libs.plugins.pambrose.kotlinter) apply false
-    alias(libs.plugins.pambrose.repos) apply false
-    alias(libs.plugins.pambrose.snapshot) apply false
-    alias(libs.plugins.pambrose.testing) apply false
 }
 
 val versionStr: String by extra
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 
-val kotlinLib = libs.plugins.jvm.get().toString().split(":").first()
-val dokkaLib = libs.plugins.dokka.get().toString().split(":").first()
-val ktlinterLib = libs.plugins.pambrose.kotlinter.get().toString().split(":").first()
-val repoLib = libs.plugins.pambrose.repos.get().toString().split(":").first()
-val snapshotLib = libs.plugins.pambrose.snapshot.get().toString().split(":").first()
-val testingLib = libs.plugins.pambrose.testing.get().toString().split(":").first()
+val jvmPluginId = libs.plugins.jvm.get().pluginId
+val dokkaPluginId = libs.plugins.dokka.get().pluginId
+val kotlinterPluginId = libs.plugins.pambrose.kotlinter.get().pluginId
 
 allprojects {
-    apply {
-        plugin(repoLib)
-    }
-    extra["versionStr"] = "1.6.2"
+    extra["versionStr"] = findProperty("overrideVersion")?.toString() ?: "1.7.0"
     extra["releaseDate"] = LocalDate.now().format(formatter)
-    group = "com.github.vapi4k.vapi4k"
+    group = "com.vapi4k"
     version = versionStr
+
+    repositories {
+        google()
+        mavenCentral()
+    }
 }
 
 subprojects {
-    tasks.withType<GenerateModuleMetadata> {
-        enabled = false
-    }
-
     apply {
         plugin("java-library")
-        plugin("maven-publish")
-        plugin(dokkaLib)
-        plugin(testingLib)
-        plugin(snapshotLib)
-        plugin(ktlinterLib)
+        plugin(dokkaPluginId)
+        plugin(kotlinterPluginId)
     }
 
     configureKotlin()
     configureDokka()
+    if (project.name != "vapi4k-snippets") configurePublishing()
     configureTesting()
 }
+
+tasks.withType<PublishToMavenRepository>().configureEach { enabled = false }
+tasks.withType<PublishToMavenLocal>().configureEach { enabled = false }
 
 dokka {
     moduleName.set("vapi4k")
@@ -79,16 +71,18 @@ dependencies {
 
 fun Project.configureKotlin() {
     apply {
-        plugin(kotlinLib)
+        plugin(jvmPluginId)
     }
 
     kotlin {
         jvmToolchain(17)
 
         sourceSets.all {
-            languageSettings.optIn("kotlinx.serialization.ExperimentalSerializationApi")
-            languageSettings.optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
-            languageSettings.optIn("kotlin.contracts.ExperimentalContracts")
+            listOf(
+                "kotlinx.serialization.ExperimentalSerializationApi",
+                "kotlin.concurrent.atomics.ExperimentalAtomicApi",
+                "kotlin.contracts.ExperimentalContracts",
+            ).forEach { languageSettings.optIn(it) }
         }
     }
 }
@@ -118,14 +112,62 @@ fun Project.configureDokka() {
     }
 }
 
-fun Project.configureTesting() {
-  tasks.test {
-    useJUnitPlatform()
-
-    testLogging {
-      events("passed", "skipped", "failed", "standardOut", "standardError")
-      exceptionFormat = TestExceptionFormat.FULL
-      showStandardStreams = true
+fun Project.configurePublishing() {
+    apply {
+        plugin("com.vanniktech.maven.publish")
     }
-  }
+
+    extensions.configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {
+        configure(
+            com.vanniktech.maven.publish.KotlinJvm(
+                javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+                sourcesJar = SourcesJar.Sources(),
+            ),
+        )
+        coordinates("com.vapi4k", project.name, version.toString())
+
+        pom {
+            name.set(project.name)
+            description.set(provider { project.description })
+            url.set("https://github.com/vapi4k/vapi4k")
+            licenses {
+                license {
+                    name.set("Apache License 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                }
+            }
+            developers {
+                developer {
+                    id.set("pambrose")
+                    name.set("Paul Ambrose")
+                    email.set("paul@pambrose.com")
+                }
+            }
+            scm {
+                connection.set("scm:git:https://github.com/vapi4k/vapi4k.git")
+                developerConnection.set("scm:git:ssh://github.com/vapi4k/vapi4k.git")
+                url.set("https://github.com/vapi4k/vapi4k")
+            }
+        }
+
+        publishToMavenCentral(automaticRelease = true)
+        signAllPublications()
+    }
+
+    // Skip signing when no GPG key is provided (e.g., local publishing)
+    tasks.withType<Sign>().configureEach {
+        isEnabled = project.findProperty("signingInMemoryKey") != null
+    }
+}
+
+fun Project.configureTesting() {
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+
+        testLogging {
+            events("passed", "skipped", "failed", "standardOut", "standardError")
+            exceptionFormat = TestExceptionFormat.FULL
+            showStandardStreams = true
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,24 +5,25 @@ config = "6.0.9"
 dokka = "2.2.0"
 exposed = "1.2.0"
 flyway = "11.8.0"
-gradle-plugins = "1.0.10"
+gradle-plugins = "1.0.12"
 hikari = "7.0.2"
 kotest = "6.0.0.M4"
 kotlin = "2.3.20"
 ktor = "3.4.2"
 logback = "1.5.32"
 logging = "8.0.01"
+maven-publish = "0.36.0"
 micrometer = "1.16.4"
 pgjdbc = "0.8.9"
 postgres = "42.7.10"
 serialization = "1.10.0"
 testcontainers = "1.21.4"
-utils = "2.6.4"
+utils = "2.7.1"
 
 [libraries]
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
-utils-json = { module = "com.github.pambrose.common-utils:json-utils", version.ref = "utils" }
+utils-json = { module = "com.pambrose.common-utils:json-utils", version.ref = "utils" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
@@ -54,7 +55,6 @@ exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datet
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "logging" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
-ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-tests = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
@@ -69,10 +69,7 @@ jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 config = { id = "com.github.gmazzo.buildconfig", version.ref = "config" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 
-pambrose-envvar = { id = "com.pambrose.envvar", version.ref = "gradle-plugins" }
 pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }
-pambrose-repos = { id = "com.pambrose.repos", version.ref = "gradle-plugins" }
-pambrose-snapshot = { id = "com.pambrose.snapshot", version.ref = "gradle-plugins" }
-pambrose-testing = { id = "com.pambrose.testing", version.ref = "gradle-plugins" }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,0 @@
-jdk:
-  - openjdk17
-install:
-  # - export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 -Dhttps.protocols=SSLv3,TLSv1,TLSv1.1,TLSv1.2,TLSv1.3"
-  # - export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.3"
-  - ./gradlew clean build -xtest
-  - ./gradlew publishToMavenLocal

--- a/llms.txt
+++ b/llms.txt
@@ -2,9 +2,9 @@
 
 > Vapi4k is a Ktor plugin and Kotlin DSL for building voice AI applications with Vapi.ai. It provides type-safe builders for configuring assistants, tools, models, voices, and call workflows.
 
-Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.6.2.
+Vapi4k is a multi-module Kotlin project targeting JVM 17. Version 1.7.0.
 
-Key dependency versions: Kotlin 2.3.20, Ktor 3.4.1, Kotlinx Serialization 1.10.0, Exposed 1.1.1, Kotest 6.0.0.M4.
+Key dependency versions: Kotlin 2.3.20, Ktor 3.4.2, Kotlinx Serialization 1.10.0, Exposed 1.2.0, Kotest 6.0.0.M4.
 
 ## Modules
 
@@ -26,17 +26,13 @@ Dependencies: vapi4k-core depends on vapi4k-utils; vapi4k-dbms depends on vapi4k
 
 ## Installation
 
-Published to JitPack under group `com.github.vapi4k.vapi4k`. Artifacts: `vapi4k-core`, `vapi4k-dbms`, `vapi4k-utils`.
+Published to Maven Central under group `com.vapi4k`. Artifacts: `vapi4k-core`, `vapi4k-dbms`, `vapi4k-utils`.
 
 ```
-repositories {
-  maven("https://jitpack.io")
-}
-
 dependencies {
-  implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.2")
+  implementation("com.vapi4k:vapi4k-core:1.7.0")
   // Optional: database persistence
-  implementation("com.github.vapi4k.vapi4k:vapi4k-dbms:1.6.2")
+  implementation("com.vapi4k:vapi4k-dbms:1.7.0")
 }
 ```
 
@@ -46,5 +42,4 @@ dependencies {
 - [KDocs (API Reference)](https://vapi4k.com/kdocs/)
 - [GitHub Repository](https://github.com/vapi4k/vapi4k)
 - [Getting Started Template](https://github.com/vapi4k/vapi4k-template)
-- [JitPack](https://jitpack.io/#vapi4k/vapi4k)
 - [Vapi.ai](https://vapi.ai)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,6 @@
 pluginManagement {
-  resolutionStrategy {
-    eachPlugin {
-      if (requested.id.namespace == "com.pambrose") {
-        useModule("com.github.pambrose:gradle-plugins:${requested.version}")
-      }
-    }
-  }
-
   repositories {
-    maven("https://jitpack.io")
+    mavenCentral()
     gradlePluginPortal()
   }
 }
@@ -16,13 +8,6 @@ pluginManagement {
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
-
-dependencyResolutionManagement {
-  repositories {
-    mavenCentral()
-  }
-}
-
 
 rootProject.name = "vapi4k"
 

--- a/vapi4k-core/build.gradle.kts
+++ b/vapi4k-core/build.gradle.kts
@@ -8,21 +8,6 @@ plugins {
 val versionStr: String by extra
 val releaseDate: String by extra
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = group.toString()
-            artifactId = project.name
-            version = versionStr
-            from(components["java"])
-        }
-    }
-}
-
-java {
-    withSourcesJar()
-}
-
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/api/vapi4k/AssistantRequestUtils.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/api/vapi4k/AssistantRequestUtils.kt
@@ -16,9 +16,9 @@
 
 package com.vapi4k.api.vapi4k
 
-import com.github.pambrose.common.json.containsKeys
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.containsKeys
+import com.pambrose.common.json.get
+import com.pambrose.common.json.stringValue
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isFunctionCall
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isStatusUpdate
 import com.vapi4k.common.FunctionName.Companion.toFunctionName

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/common/Version.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/common/Version.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.common
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.common.Constants.UNKNOWN
 import com.vapi4k.utils.DateUtils.TIME_ZONE
 import com.vapi4k.utils.DateUtils.toFullDateString

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/console/ConsoleInfo.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/console/ConsoleInfo.kt
@@ -16,8 +16,8 @@
 
 package com.vapi4k.console
 
-import com.github.pambrose.common.json.toJsonElement
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.common.Version.Companion.versionDesc
 import com.vapi4k.console.ValidateAssistant.navBar
 import com.vapi4k.console.ValidateAssistant.singleNavItem

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/console/InvokeTool.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/console/InvokeTool.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.console
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.common.ApplicationId.Companion.toApplicationId
 import com.vapi4k.common.AssistantId.Companion.toAssistantId
 import com.vapi4k.common.Constants.FUNCTION_NAME

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateApplication.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateApplication.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.console
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.common.ApplicationName.Companion.toApplicationName
 import com.vapi4k.common.AssistantId.Companion.EMPTY_ASSISTANT_ID
 import com.vapi4k.common.Constants.APP_NAME

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateAssistant.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateAssistant.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.console
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.common.CssNames.ACTIVE
 import com.vapi4k.common.CssNames.ERROR_MSG
 import com.vapi4k.common.CssNames.FUNCTIONS

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateTools.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/console/ValidateTools.kt
@@ -16,12 +16,12 @@
 
 package com.vapi4k.console
 
-import com.github.pambrose.common.json.containsKeys
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.containsKeys
+import com.pambrose.common.json.get
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.common.AssistantId
 import com.vapi4k.common.AssistantId.Companion.EMPTY_ASSISTANT_ID
 import com.vapi4k.common.AssistantId.Companion.getAssistantIdFromSuffix

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/call/ProcessOutboundCall.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/call/ProcessOutboundCall.kt
@@ -16,9 +16,9 @@
 
 package com.vapi4k.dsl.call
 
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.get
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.call.OutboundCall
 import com.vapi4k.api.call.Phone
 import com.vapi4k.common.CoreEnvVars.vapi4kBaseUrl

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/call/VapiApiImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/call/VapiApiImpl.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.dsl.call
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.api.call.ApiObjectType
 import com.vapi4k.api.call.OutboundCall
 import com.vapi4k.api.call.Phone

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/functions/FunctionDetails.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/functions/FunctionDetails.kt
@@ -16,11 +16,11 @@
 
 package com.vapi4k.dsl.functions
 
-import com.github.pambrose.common.json.booleanValue
-import com.github.pambrose.common.json.doubleValue
-import com.github.pambrose.common.json.intValue
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.booleanValue
+import com.pambrose.common.json.doubleValue
+import com.pambrose.common.json.intValue
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.stringValue
 import com.vapi4k.api.toolservice.ToolCallService
 import com.vapi4k.api.vapi4k.RequestContext
 import com.vapi4k.common.Utils.errorMsg

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/vapi4k/AbstractApplicationImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/vapi4k/AbstractApplicationImpl.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.dsl.vapi4k
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.tools.TransferDestinationResponse
 import com.vapi4k.api.vapi4k.RequestContext
 import com.vapi4k.api.vapi4k.ResponseContext

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/plugin/Vapi4kServer.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/plugin/Vapi4kServer.kt
@@ -16,9 +16,9 @@
 
 package com.vapi4k.plugin
 
-import com.github.pambrose.common.json.defaultJsonConfig
-import com.github.pambrose.common.json.toJsonElement
-import com.github.vapi4k.vapi4k.BuildConfig
+import com.pambrose.common.json.defaultJsonConfig
+import com.pambrose.common.json.toJsonElement
+import com.vapi4k.BuildConfig
 import com.vapi4k.api.vapi4k.Vapi4kConfig
 import com.vapi4k.common.Constants.APP_NAME
 import com.vapi4k.common.Constants.APP_TYPE

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/responses/ToolCallResponse.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/responses/ToolCallResponse.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.responses
 
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.stringValue
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.id
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.toolCallArguments
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.toolCallName

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/server/InboundCallActions.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/server/InboundCallActions.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.server
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.vapi4k.ServerRequestType.ASSISTANT_REQUEST
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.serverRequestType
 import com.vapi4k.api.vapi4k.ServerRequestType.END_OF_CALL_REPORT

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/server/OutboundCallAndWebActions.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/server/OutboundCallAndWebActions.kt
@@ -16,11 +16,11 @@
 
 package com.vapi4k.server
 
-import com.github.pambrose.common.json.containsKeys
-import com.github.pambrose.common.json.getOrNull
-import com.github.pambrose.common.json.isNotEmpty
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.containsKeys
+import com.pambrose.common.json.getOrNull
+import com.pambrose.common.json.isNotEmpty
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.vapi4k.ServerRequestType.ASSISTANT_REQUEST
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.serverRequestType
 import com.vapi4k.api.vapi4k.ServerRequestType.END_OF_CALL_REPORT

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/server/RequestContextImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/server/RequestContextImpl.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.server
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.hasStatusUpdateError
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.phoneNumber
 import com.vapi4k.api.vapi4k.AssistantRequestUtils.statusUpdateError

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/server/ResponseContextImpl.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/server/ResponseContextImpl.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.server
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.api.vapi4k.RequestContext
 import com.vapi4k.api.vapi4k.ResponseContext
 import com.vapi4k.api.vapi4k.ServerRequestType

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/utils/DslUtils.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/utils/DslUtils.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.utils
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.plugin.Vapi4kServer.logger
 
 object DslUtils {

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/utils/HttpUtils.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/utils/HttpUtils.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.utils
 
-import com.github.pambrose.common.json.JsonContentUtils.prettyFormat
+import com.pambrose.common.json.JsonContentUtils.prettyFormat
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.cio.CIO

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/utils/JsonUtils.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/utils/JsonUtils.kt
@@ -16,12 +16,12 @@
 
 package com.vapi4k.utils
 
-import com.github.pambrose.common.json.containsKeys
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValueOrNull
-import com.github.pambrose.common.json.toJsonElement
-import com.github.pambrose.common.json.toJsonElementList
+import com.pambrose.common.json.containsKeys
+import com.pambrose.common.json.get
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.stringValueOrNull
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElementList
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isToolCall
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray

--- a/vapi4k-core/src/test/kotlin/Assistant.kt
+++ b/vapi4k-core/src/test/kotlin/Assistant.kt
@@ -14,7 +14,7 @@
  *
  */
 
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.stringValue
 import com.vapi4k.FavoriteFoodService
 import com.vapi4k.WeatherLookupByAreaCodeService
 import com.vapi4k.WeatherLookupService1

--- a/vapi4k-core/src/test/kotlin/CallExample.kt
+++ b/vapi4k-core/src/test/kotlin/CallExample.kt
@@ -14,7 +14,7 @@
  *
  */
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.dsl.call.VapiApiImpl.Companion.vapiApi
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking

--- a/vapi4k-core/src/test/kotlin/SerializationIssue.kt
+++ b/vapi4k-core/src/test/kotlin/SerializationIssue.kt
@@ -1,4 +1,4 @@
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/vapi4k-core/src/test/kotlin/SpeachListener.kt
+++ b/vapi4k-core/src/test/kotlin/SpeachListener.kt
@@ -1,5 +1,5 @@
-import com.github.pambrose.common.json.JsonContentUtils.prettyFormat
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.JsonContentUtils.prettyFormat
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.common.CoreEnvVars.deepGramVoiceIdType
 import com.vapi4k.plugin.Vapi4kServer.logger
 import com.vapi4k.utils.HttpUtils.jsonHttpClient
@@ -16,6 +16,9 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readBytes
 import io.ktor.websocket.readText
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.thread
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -24,9 +27,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.io.File
-import java.util.concurrent.ConcurrentHashMap
-import kotlin.concurrent.thread
 
 @Serializable
 class DeepGramProperties(

--- a/vapi4k-core/src/test/kotlin/TalkPage.kt
+++ b/vapi4k-core/src/test/kotlin/TalkPage.kt
@@ -1,4 +1,4 @@
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.web.MethodType
 import com.vapi4k.dsl.web.VapiWeb.vapiTalkButton
 import kotlinx.html.HTML

--- a/vapi4k-core/src/test/kotlin/Vapi4kApplication.kt
+++ b/vapi4k-core/src/test/kotlin/Vapi4kApplication.kt
@@ -16,8 +16,8 @@
 
 import SpeachListener.listenTo
 import TalkPage.talkPage
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.FavoriteFoodService
 import com.vapi4k.WeatherLookupByAreaCodeService
 import com.vapi4k.WeatherLookupService1

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/AssistantTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/AssistantTest.kt
@@ -16,10 +16,10 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.intValue
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.intValue
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.assistant.AssistantClientMessageType
 import com.vapi4k.api.assistant.AssistantServerMessageType
 import com.vapi4k.api.assistant.FirstMessageModeType.ASSISTANT_SPEAKS_FIRST_WITH_MODEL_GENERATED_MODEL

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/BaseToolMessageTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/BaseToolMessageTest.kt
@@ -16,8 +16,8 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.stringValue
 import com.vapi4k.api.model.OpenAIModelType
 import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
 import com.vapi4k.utils.JsonFilenames

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/EOCRCacheTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/EOCRCacheTest.kt
@@ -16,9 +16,9 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.intValue
-import com.github.pambrose.common.json.keys
+import com.pambrose.common.json.get
+import com.pambrose.common.json.intValue
+import com.pambrose.common.json.keys
 import com.vapi4k.DoubleToolAssistant.doubleToolAssistant
 import com.vapi4k.common.CoreEnvVars.defaultServerPath
 import com.vapi4k.common.Endpoints.CACHES_PATH

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.tools.ToolCall
 import com.vapi4k.api.toolservice.ToolCallService
 import com.vapi4k.api.vapi4k.RequestContext

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/JsonExtensionTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/JsonExtensionTest.kt
@@ -16,10 +16,10 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.get
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.utils.JsonUtils.toObjectList
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ModelProviderTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ModelProviderTest.kt
@@ -16,9 +16,9 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.jsonElementList
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.AnthropicModelType
 import com.vapi4k.api.model.GroqModelType

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ModelTests.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ModelTests.kt
@@ -16,11 +16,11 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.booleanValue
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.booleanValue
+import com.pambrose.common.json.get
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.OpenAIModelType
 import com.vapi4k.utils.assistantResponse

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ResponseTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ResponseTest.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.AnthropicModelType
 import com.vapi4k.api.transcriber.DeepgramModelType

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ServerRoutingTest.kt
@@ -18,12 +18,12 @@ package com.vapi4k
 
 import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.common.CoreEnvVars.defaultServerPath
+import com.vapi4k.common.Headers.VAPI_SECRET_HEADER
 import com.vapi4k.common.QueryParams.SECRET_PARAM
 import com.vapi4k.common.Utils.resourceFile
 import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
 import com.vapi4k.plugin.Vapi4k
 import io.kotest.core.spec.style.StringSpec
-import com.vapi4k.common.Headers.VAPI_SECRET_HEADER
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
 import io.ktor.client.request.post

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ServerTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ServerTest.kt
@@ -16,11 +16,10 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.intValue
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
+import com.pambrose.common.json.get
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.stringValue
 import com.vapi4k.DoubleToolAssistant.doubleToolAssistant
 import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.common.CoreEnvVars.defaultServerPath
@@ -29,7 +28,6 @@ import com.vapi4k.common.Utils.ensureStartsWith
 import com.vapi4k.dsl.vapi4k.ApplicationType.INBOUND_CALL
 import com.vapi4k.plugin.Vapi4k
 import com.vapi4k.utils.JsonFilenames
-import com.vapi4k.utils.JsonUtils.firstInList
 import com.vapi4k.utils.withTestApplication
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/TransferDestinationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/TransferDestinationTest.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.common.AssistantId.Companion.toAssistantId
 import com.vapi4k.common.SessionId.Companion.toSessionId
 import com.vapi4k.dsl.vapi4k.InboundCallApplicationImpl

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceProviderTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceProviderTest.kt
@@ -16,8 +16,8 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.api.voice.AzureVoiceIdType

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/VoiceTest.kt
@@ -16,12 +16,12 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.booleanValue
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.intValue
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.booleanValue
+import com.pambrose.common.json.get
+import com.pambrose.common.json.intValue
+import com.pambrose.common.json.jsonElementList
 import com.vapi4k.AssistantTest.Companion.newRequestContext
 import com.vapi4k.api.model.GroqModelType
 import com.vapi4k.api.voice.CartesiaVoiceLanguageType

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/utils/TestUtils.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/utils/TestUtils.kt
@@ -16,13 +16,13 @@
 
 package com.vapi4k.utils
 
-import com.github.pambrose.common.json.containsKeys
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.jsonElementList
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
-import com.github.pambrose.common.json.toJsonElementList
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElementList
+import com.pambrose.common.json.toJsonString
+import com.pambrose.common.json.containsKeys
+import com.pambrose.common.json.get
+import com.pambrose.common.json.jsonElementList
 import com.vapi4k.ServerTest.Companion.configPost
 import com.vapi4k.api.response.InboundCallAssistantResponse
 import com.vapi4k.api.tools.ToolMessageType

--- a/vapi4k-core/src/test/kotlin/simpledemo/TimeLookupService.kt
+++ b/vapi4k-core/src/test/kotlin/simpledemo/TimeLookupService.kt
@@ -17,10 +17,10 @@
 package simpledemo
 
 import com.vapi4k.api.tools.ToolCall
-import simpledemo.Coasts.EAST
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import simpledemo.Coasts.EAST
 
 class TimeLookupService(
   val coast: Coasts,

--- a/vapi4k-core/src/test/kotlin/simpledemo/WeatherLookupService.kt
+++ b/vapi4k-core/src/test/kotlin/simpledemo/WeatherLookupService.kt
@@ -16,9 +16,9 @@
 
 package simpledemo
 
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
-import com.github.pambrose.common.json.toJsonElementList
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElementList
 import com.vapi4k.api.tools.ToolCall
 import com.vapi4k.utils.HttpUtils.jsonHttpClient
 import io.ktor.client.request.get

--- a/vapi4k-dbms/build.gradle.kts
+++ b/vapi4k-dbms/build.gradle.kts
@@ -31,21 +31,6 @@ val releaseDate: String by extra
 
 description = project.name
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = group.toString()
-            artifactId = description
-            version = versionStr
-            from(components["java"])
-        }
-    }
-}
-
-java {
-    withSourcesJar()
-}
-
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/vapi4k-dbms/src/main/kotlin/com/vapi4k/api/DbmsPool.kt
+++ b/vapi4k-dbms/src/main/kotlin/com/vapi4k/api/DbmsPool.kt
@@ -19,8 +19,8 @@ package com.vapi4k.api
 import com.vapi4k.dbms.DbmsEnvVars
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import org.jetbrains.exposed.v1.jdbc.Database
 import kotlin.time.Duration.Companion.minutes
+import org.jetbrains.exposed.v1.jdbc.Database
 
 object DbmsPool {
   fun connectToDbms() = database

--- a/vapi4k-dbms/src/main/kotlin/com/vapi4k/api/Messages.kt
+++ b/vapi4k-dbms/src/main/kotlin/com/vapi4k/api/Messages.kt
@@ -16,14 +16,14 @@
 
 package com.vapi4k.api
 
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.toJsonString
 import com.vapi4k.api.vapi4k.ServerRequestType
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.serverRequestType
 import com.vapi4k.dbms.MessagesTable
+import kotlin.time.Duration
 import kotlinx.serialization.json.JsonElement
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import kotlin.time.Duration
 
 object Messages {
   fun insertRequest(request: JsonElement) {

--- a/vapi4k-dbms/src/test/kotlin/com/vapi4k/dbms/MessagesTest.kt
+++ b/vapi4k-dbms/src/test/kotlin/com/vapi4k/dbms/MessagesTest.kt
@@ -4,13 +4,13 @@ import com.vapi4k.api.Messages
 import com.vapi4k.api.vapi4k.ServerRequestType
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteAll
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import kotlin.time.Duration.Companion.milliseconds
 
 class MessagesTest : StringSpec() {
   init {

--- a/vapi4k-snippets/src/main/kotlin/applications/CallCustomer.kt
+++ b/vapi4k-snippets/src/main/kotlin/applications/CallCustomer.kt
@@ -16,7 +16,7 @@
 
 package applications
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.dsl.call.VapiApiImpl.Companion.vapiApi
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking

--- a/vapi4k-snippets/src/main/kotlin/applications/TalkPage.kt
+++ b/vapi4k-snippets/src/main/kotlin/applications/TalkPage.kt
@@ -16,7 +16,7 @@
 
 package applications
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.dsl.web.VapiWeb.vapiTalkButton
 import io.ktor.server.application.Application
 import io.ktor.server.html.respondHtml

--- a/vapi4k-snippets/src/main/kotlin/tools/ManualTools.kt
+++ b/vapi4k-snippets/src/main/kotlin/tools/ManualTools.kt
@@ -16,7 +16,7 @@
 
 package tools
 
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.stringValue
 import com.vapi4k.dsl.model.CommonModelProperties
 import kotlinx.serialization.json.JsonElement
 

--- a/vapi4k-snippets/src/main/kotlin/utils/JsonElements.kt
+++ b/vapi4k-snippets/src/main/kotlin/utils/JsonElements.kt
@@ -16,11 +16,11 @@
 
 package utils
 
-import com.github.pambrose.common.json.get
-import com.github.pambrose.common.json.keys
-import com.github.pambrose.common.json.stringValue
-import com.github.pambrose.common.json.toJsonElement
-import com.github.pambrose.common.json.toJsonString
+import com.pambrose.common.json.keys
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonString
+import com.pambrose.common.json.get
 import kotlinx.serialization.json.JsonElement
 
 object JsonElements {

--- a/vapi4k-utils/build.gradle.kts
+++ b/vapi4k-utils/build.gradle.kts
@@ -8,21 +8,6 @@ val releaseDate: String by extra
 
 description = project.name
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = group.toString()
-            artifactId = description
-            version = versionStr
-            from(components["java"])
-        }
-    }
-}
-
-java {
-    withSourcesJar()
-}
-
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/vapi4k-utils/src/main/kotlin/com/vapi4k/api/vapi4k/ServerRequestType.kt
+++ b/vapi4k-utils/src/main/kotlin/com/vapi4k/api/vapi4k/ServerRequestType.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k.api.vapi4k
 
-import com.github.pambrose.common.json.stringValue
+import com.pambrose.common.json.stringValue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.json.JsonElement
 

--- a/vapi4k-utils/src/test/kotlin/com/vapi4k/ServerRequestTypeTest.kt
+++ b/vapi4k-utils/src/test/kotlin/com/vapi4k/ServerRequestTypeTest.kt
@@ -16,7 +16,7 @@
 
 package com.vapi4k
 
-import com.github.pambrose.common.json.toJsonElement
+import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.vapi4k.ServerRequestType
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isAssistantRequest
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.isEndOfCallReport


### PR DESCRIPTION
## Summary

- Migrate artifact publishing from JitPack to Maven Central with new group ID `com.vapi4k`
- Adopt Vanniktech Maven Publish plugin with automatic release, GPG signing, and POM metadata
- Bump version to 1.7.0 and update all dependency coordinates (`com.github.pambrose` → `com.pambrose`)
- Add CHANGELOG.md (all 21 releases) and RELEASE_NOTES.md for v1.7.0
- Update README.md, llms.txt, and CLAUDE.md with new coordinates and documentation

## Breaking Changes

Consumers must update their dependency declarations:
```kotlin
// Before
implementation("com.github.vapi4k.vapi4k:vapi4k-core:1.6.2")

// After
implementation("com.vapi4k:vapi4k-core:1.7.0")
```

## Test plan

- [ ] Verify `./gradlew build` succeeds
- [ ] Verify `./gradlew publishToMavenLocal` produces artifacts under `com.vapi4k`
- [ ] Verify `./gradlew test` passes
- [ ] Confirm Maven Central badge resolves in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)