### PR TITLE
Add project descriptions for Maven Central publishing

### DIFF
--- a/vapi4k-core/build.gradle.kts
+++ b/vapi4k-core/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
+description = "Ktor plugin and Kotlin DSL for building voice AI applications with Vapi.ai"
+
 val versionStr: String by extra
 val releaseDate: String by extra
 

--- a/vapi4k-dbms/build.gradle.kts
+++ b/vapi4k-dbms/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 val versionStr: String by extra
 val releaseDate: String by extra
 
-description = project.name
+description = "Database persistence module for the vapi4k framework"
 
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/vapi4k-utils/build.gradle.kts
+++ b/vapi4k-utils/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 val versionStr: String by extra
 val releaseDate: String by extra
 
-description = project.name
+description = "Shared utilities for the vapi4k framework"
 
 tasks.withType<Zip> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE


### PR DESCRIPTION
## Summary
- Add `description` to `vapi4k-core`, `vapi4k-utils`, and `vapi4k-dbms` build files
- Fixes Maven Central validation error: "Project description is missing"

## Test plan
- [ ] Verify `./gradlew publishToMavenLocal` succeeds
- [ ] Confirm POM files contain descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)