### PR TITLE
Centralize repositories in settings.gradle.kts and add GPG key ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ publish-local-snapshot:
 
 GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
 check-gpg-env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,11 +31,6 @@ allprojects {
     findProperty("overrideVersion")?.toString()?.let { version = it }
     extra["versionStr"] = version.toString()
     extra["releaseDate"] = LocalDate.now().format(formatter)
-
-    repositories {
-        google()
-        mavenCentral()
-    }
 }
 
 subprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,19 @@
 pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
 }
 
 plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
 }
 
 rootProject.name = "vapi4k"


### PR DESCRIPTION
## Summary
- Move repository declarations from `build.gradle.kts` into `settings.gradle.kts` under `dependencyResolutionManagement` with `RepositoriesMode.FAIL_ON_PROJECT_REPOS` so subprojects can no longer declare their own repos
- Align `settings.gradle.kts` indentation with the rest of the build scripts
- Add `ORG_GRADLE_PROJECT_signingInMemoryKeyId` to the Makefile `GPG_ENV` so in-memory signing has the key ID it requires

Follow-up to #47 — these edits raced the merge and didn't land in that PR.

## Test plan
- [ ] `./gradlew build`
- [ ] `make publish-local`
- [ ] `make check-gpg-env` (and a publish dry run if practical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)