### PR TITLE
Refresh build tooling: Makefile, Dokka scoping, test logging, version catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help build-all stop clean build build-tests cont-build tests \
+.PHONY: default help stop clean build build-tests cont-build tests \
 	lint format detekt \
 	versioncheck refresh updatedocs kdocs \
 	publish-local publish-local-snapshot \
@@ -13,12 +13,10 @@ GPG_ENV := \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
-default: versioncheck
+default: versioncheck ## Default target (runs versioncheck)
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
-
-build-all: build ## Clean and build everything (skips tests)
 
 stop: ## Stop running Gradle daemons
 	./gradlew --stop
@@ -39,7 +37,7 @@ cont-build: ## Continuous build watch (skips tests)
 tests: ## Re-run the full check suite (tests, lint, etc.)
 	./gradlew --rerun-tasks check
 
-lint: ## Run detekt then kotlinter lintKotlin
+lint: ## Run kotlinter lintKotlin then detekt
 	./gradlew lintKotlin detekt
 
 format: ## Run kotlinter formatKotlin
@@ -60,19 +58,23 @@ updatedocs: ## Run bin/update-docs.sh
 kdocs: ## Generate KDoc HTML via Dokka
 	./gradlew :dokkaGenerate
 
-publish-local: _require-version  ## Publish all artifacts to ~/.m2 (Maven Local)
+publish-local: _require-version ## Publish all artifacts to ~/.m2 (Maven Local)
 	./gradlew publishToMavenLocal
 
-publish-local-snapshot: _require-version  ## Publish -SNAPSHOT artifacts to ~/.m2
+publish-local-snapshot: _require-version ## Publish -SNAPSHOT artifacts to ~/.m2/repositories
 	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
 
-publish-snapshot: _require-version _check-gpg-env  ## Publish -SNAPSHOT artifacts to Maven Central
+publish-snapshot: _require-version _check-gpg-env ## Publish -SNAPSHOT artifacts to Maven Central
 	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
-publish-maven-central: _require-version _check-gpg-env  ## Publish and release to Maven Central
+publish-maven-central: _require-version _check-gpg-env ## Publish and release to Maven Central
 	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
+# Gradle's documented upgrade procedure: the first run rewrites
+# gradle-wrapper.properties using the *old* wrapper jar; the second run
+# regenerates the wrapper itself with the new version.
 upgrade-wrapper: _require-gradle-version ## Upgrade the Gradle wrapper to the version in libs.versions.toml
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 
 _check-gpg-env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import com.vanniktech.maven.publish.SourcesJar
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 
@@ -37,13 +38,13 @@ allprojects {
 subprojects {
     apply {
         plugin("java-library")
-        plugin(dokkaPluginId)
         plugin(kotlinterPluginId)
     }
 
     configureKotlin()
-    configureDokka()
     if (project.name != "vapi4k-snippets") {
+        apply { plugin(dokkaPluginId) }
+        configureDokka()
         configurePublishing()
         configureDetekt()
         configureKover()
@@ -60,9 +61,23 @@ tasks.withType<PublishToMavenLocal>().configureEach { enabled = false }
 // rejects. ben-manes catches and silently drops the whole config, so test-only
 // deps (kotest, flyway, testcontainers, ktor-server-tests) vanish from the
 // report instead of being flagged "unresolved". Skip them explicitly so the
-// gap is intentional, not invisible.
+// gap is intentional, not invisible, and remind the user at the end of the
+// report to check those versions manually.
+val testOnlyVersionKeys = listOf("kotest", "flyway", "testcontainers")
+val libsCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 tasks.withType<DependencyUpdatesTask>().configureEach {
     filterConfigurations = Spec { !it.name.startsWith("test") }
+
+    doLast {
+        val pad = testOnlyVersionKeys.maxOf { it.length }
+        logger.lifecycle("")
+        logger.lifecycle("Test-only dependencies not checked above (Gradle 9 + KGP limitation).")
+        logger.lifecycle("Verify these versions manually against their release pages:")
+        testOnlyVersionKeys.forEach { key ->
+            val version = libsCatalog.findVersion(key).orElseThrow().requiredVersion
+            logger.lifecycle("  ${key.padEnd(pad)}  $version")
+        }
+    }
 }
 
 dokka {
@@ -131,7 +146,6 @@ fun Project.configureDokka() {
 
 fun Project.configurePublishing() {
     apply {
-        plugin(dokkaPluginId)
         plugin(mavenPublishPluginId)
     }
 
@@ -151,7 +165,12 @@ fun Project.configurePublishing() {
         coordinates(group.toString(), project.name, version.toString())
 
         pom {
-            name.set(project.name)
+            name.set(
+                project.name.split("-").joinToString(" ") { part ->
+                    if (part.equals("dbms", ignoreCase = true)) "DBMS"
+                    else part.replaceFirstChar { it.uppercaseChar() }
+                },
+            )
             description.set(provider { project.description })
             url.set(projectUrl)
             licenses {
@@ -189,9 +208,9 @@ fun Project.configureTesting() {
         useJUnitPlatform()
 
         testLogging {
-            events("passed", "skipped", "failed", "standardOut", "standardError")
+            events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR)
             exceptionFormat = TestExceptionFormat.FULL
-            showStandardStreams = true
+            showStandardStreams = false
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,6 @@ version=1.7.1
 
 kotlin.code.style=official
 org.gradle.configuration-cache=true
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,38 +1,53 @@
 [versions]
+# Toolchain
+gradle = "9.5.0"
+jvm = "17"
+kotlin = "2.3.21"
+
+# Build plugins
 config = "6.0.9"
 detekt = "1.23.8"
 dokka = "2.2.0"
-exposed = "1.2.0"
-flyway = "11.8.0"
-gradle = "9.5.0"
 gradle-plugins = "1.0.14"
-hikari = "7.0.2"
-jvm = "17"
-kotest = "6.1.11"
-kotlin = "2.3.21"
 kover = "0.9.8"
-ktor = "3.4.3"
-logback = "1.5.32"
-logging = "8.0.02"
 maven-publish = "0.36.0"
-micrometer = "1.16.5"
-pgjdbc = "0.8.9"
-postgres = "42.7.11"
+
+# Core libraries
+ktor = "3.4.3"
 serialization = "1.11.0"
-testcontainers = "1.21.4"
 utils = "2.8.2"
 
-[libraries]
-kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+# Logging
+logback = "1.5.32"
+logging = "8.0.02"
 
+# Metrics
+micrometer = "1.16.5"
+
+# Database
+exposed = "1.2.0"
+flyway = "11.8.0"
+hikari = "7.0.2"
+pgjdbc = "0.8.9"
+postgres = "42.7.11"
+
+# Testing
+kotest = "6.1.11"
+testcontainers = "1.21.4"
+
+[libraries]
+# Serialization & JSON
+kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 utils-json = { module = "com.pambrose.common-utils:json-utils", version.ref = "utils" }
 
+# Ktor client
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 
+# Ktor server
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
@@ -42,10 +57,12 @@ ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negoti
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 ktor-server-html-builder = { module = "io.ktor:ktor-server-html-builder", version.ref = "ktor" }
 ktor-server-metrics-micrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor" }
-
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+# Metrics
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 
+# Database
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 pgjdbc-ng = { module = "com.impossibl.pgjdbc-ng:pgjdbc-ng-all", version.ref = "pgjdbc" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
@@ -53,27 +70,35 @@ exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "e
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
 exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
-
-kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "logging" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-
-ktor-server-tests = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
-kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-postgres = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 
+# Logging
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "logging" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+# Testing
+ktor-server-tests = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 
 [plugins]
+# Kotlin
 jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+# Code generation & docs
 config = { id = "com.github.gmazzo.buildconfig", version.ref = "config" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+
+# Code quality
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
-
-pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }
+
+# Dependency updates
+pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
+
+# Publishing
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/vapi4k-core/build.gradle.kts
+++ b/vapi4k-core/build.gradle.kts
@@ -40,12 +40,6 @@ buildConfig {
     buildConfigField("long", "BUILD_TIME", buildTime.map { "${it}L" })
 }
 
-sourceSets {
-    named("main") {
-        java.srcDir("build/generated/sources/buildConfig/main")
-    }
-}
-
 dependencies {
     api(project(":vapi4k-utils"))
 
@@ -71,7 +65,6 @@ dependencies {
     testImplementation(libs.kotest.runner)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.ktor.server.tests)
-    // testImplementation(libs.ktor.client.mock)
 }
 
 dokka {


### PR DESCRIPTION
## Summary
- Scope Dokka to publishable subprojects only (skip `vapi4k-snippets`), capitalize POM names (e.g. `DBMS`), switch test logging to the `TestLogEvent` enum and silence stdout, and surface test-only deps that `dependencyUpdates` skips.
- Tidy the `Makefile`: drop the unused `build-all` target, correct the `lint` help text, document the two-pass `upgrade-wrapper` procedure, and align help columns.
- Enable the Gradle build cache and reorganize `libs.versions.toml` into purpose-based sections (toolchain, build plugins, core libs, logging, metrics, database, testing). Drop the redundant `buildConfig` srcDir and a stale commented dependency in `vapi4k-core`.

## Test plan
- [ ] `./gradlew build`
- [ ] `./gradlew test`
- [ ] `./gradlew lintKotlin detekt`
- [ ] `./gradlew dependencyUpdates` shows the test-only reminder block
- [ ] `./gradlew dokkaGenerate` only runs for publishable subprojects

🤖 Generated with [Claude Code](https://claude.com/claude-code)