### PR TITLE
Add tests for tool-call failure path and validate not-found rendering

### DIFF
--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ToolCallResponseTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ToolCallResponseTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.pambrose.common.json.toJsonElement
+import com.vapi4k.common.AssistantId.Companion.toAssistantId
+import com.vapi4k.common.SessionId.Companion.toSessionId
+import com.vapi4k.dsl.vapi4k.InboundCallApplicationImpl
+import com.vapi4k.responses.ToolCallResponseDto.Companion.getToolCallResponse
+import com.vapi4k.server.RequestContextImpl
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.string.shouldContain
+
+class ToolCallResponseTest : StringSpec() {
+  private fun requestContextForTool(toolName: String): RequestContextImpl {
+    val request =
+      """
+      {
+        "message": {
+          "type": "tool-calls",
+          "toolCallList": [
+            { "id": "call_1", "type": "function", "function": { "name": "$toolName", "arguments": {} } }
+          ]
+        }
+      }
+      """.trimIndent().toJsonElement()
+    return RequestContextImpl(
+      application = InboundCallApplicationImpl(),
+      request = request,
+      sessionId = "test-session".toSessionId(),
+      assistantId = "test-assistant".toAssistantId(),
+    )
+  }
+
+  init {
+    // Exercises the onFailure branch of getToolCallResponse: an unknown tool throws
+    // ("Tool not found"), which must be caught and recorded on the result rather than
+    // propagated. Guards the getOrElse -> onFailure change.
+    "getToolCallResponse records an error when the tool is not found" {
+      val response = getToolCallResponse(requestContextForTool("missingTool"))
+      val dto = response.messageResponse
+
+      dto.results shouldHaveSize 1
+      dto.results.first().error shouldContain "Tool not found"
+      dto.error shouldContain "Tool not found"
+    }
+  }
+}

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ValidateApplicationTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ValidateApplicationTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.plugin.Vapi4k
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.basicAuth
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+
+class ValidateApplicationTest : StringSpec() {
+  init {
+    // Drives the "application not found" branch of validateApplication. Without the
+    // kotlinx.html unaryPlus on the <p>, the message string is discarded and the
+    // element renders empty, so this assertion guards that fix.
+    "validateApplication renders a not-found message for an unknown app" {
+      testApplication {
+        application { install(Vapi4k) }
+        val response =
+          client.get("/validate/inboundCall/no-such-app") {
+            basicAuth("admin", "admin")
+          }
+        response.status shouldBe HttpStatusCode.OK
+        response.bodyAsText() shouldContain "Application for /no-such-app not found"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follows up #53 by covering the two behavioral fixes that the patch-coverage gate flagged as untested.

- **`ToolCallResponseTest`** — drives `getToolCallResponse` with an unknown tool name so the `onFailure` branch records the error on the result rather than propagating it.
- **`ValidateApplicationTest`** — `GET`s the admin validate route for an unconfigured app and asserts the rendered HTML contains the not-found message. That message only appears because of the kotlinx.html `+` fix — verified the test fails if the `+` is removed.

Test-only change; full `:vapi4k-core:test` is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)