### PR TITLE
Reduce complexity of startCallbackThread and add callback dispatch tests

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/server/AdminJobs.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/server/AdminJobs.kt
@@ -16,6 +16,7 @@
 
 package com.vapi4k.server
 
+import com.vapi4k.api.vapi4k.ServerRequestType
 import com.vapi4k.api.vapi4k.ServerRequestType.Companion.serverRequestType
 import com.vapi4k.common.CoreEnvVars.TOOL_CACHE_CLEAN_PAUSE_MINS
 import com.vapi4k.common.CoreEnvVars.TOOL_CACHE_MAX_AGE_MINS
@@ -26,6 +27,7 @@ import com.vapi4k.dsl.vapi4k.Vapi4kConfigImpl
 import com.vapi4k.plugin.Vapi4kServer.logger
 import com.vapi4k.server.RequestResponseCallback.Companion.requestCallback
 import com.vapi4k.server.RequestResponseCallback.Companion.responseCallback
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -55,7 +57,6 @@ internal object AdminJobs {
       }
     }
 
-  @Suppress("CyclomaticComplexMethod")
   fun startCallbackThread(config: Vapi4kConfigImpl) =
     thread(isDaemon = true) {
       while (true) {
@@ -64,68 +65,8 @@ internal object AdminJobs {
             for (callback in config.callbackChannel) {
               coroutineScope {
                 when (callback.type) {
-                  REQUEST -> {
-                    config.allApplications
-                      .filter { it.applicationId == callback.applicationId }
-                      .forEach { app ->
-                        with(app) {
-                          applicationAllRequests.forEach { launch { it.invoke(callback.toRequestContext(config)) } }
-                          applicationPerRequests
-                            .filter { it.first == callback.request.serverRequestType }
-                            .forEach { (_, block) -> launch { block(callback.toRequestContext(config)) } }
-                        }
-                      }
-
-                    with(config) {
-                      globalAllRequests.forEach { launch { it.invoke(callback.toRequestContext(config)) } }
-                      globalPerRequests
-                        .filter { it.first == callback.request.serverRequestType }
-                        .forEach { (_, block) -> launch { block(callback.toRequestContext(config)) } }
-                    }
-                  }
-
-                  RESPONSE -> {
-                    val hasAppCallbacks = config.allApplications.any { app ->
-                      app.applicationAllResponses.isNotEmpty() || app.applicationPerResponses.isNotEmpty()
-                    }
-                    val hasGlobalCallbacks = config.globalAllResponses.isNotEmpty() ||
-                      config.globalPerResponses.isNotEmpty()
-
-                    if (hasAppCallbacks || hasGlobalCallbacks) {
-                      val resp = runCatching {
-                        callback.response.invoke()
-                      }.onFailure { e ->
-                        logger.error { "Error creating response" }
-                        error("Error creating response")
-                      }.getOrThrow()
-
-                      config.allApplications.forEach { application ->
-                        with(application) {
-                          if (applicationAllResponses.isNotEmpty() || applicationPerResponses.isNotEmpty()) {
-                            applicationAllResponses.forEach {
-                              launch { it.invoke(callback.toResponseContext(config, resp)) }
-                            }
-                            applicationPerResponses
-                              .filter { it.first == callback.request.serverRequestType }
-                              .forEach { (_, block) ->
-                                launch { block(callback.toResponseContext(config, resp)) }
-                              }
-                          }
-                        }
-                      }
-
-                      with(config) {
-                        globalAllResponses.forEach {
-                          launch { it.invoke(callback.toResponseContext(config, resp)) }
-                        }
-                        globalPerResponses
-                          .filter { it.first == callback.request.serverRequestType }
-                          .forEach { (_, block) ->
-                            launch { block(callback.toResponseContext(config, resp)) }
-                          }
-                      }
-                    }
-                  }
+                  REQUEST -> dispatchRequestCallbacks(config, callback)
+                  RESPONSE -> dispatchResponseCallbacks(config, callback)
                 }
               }
             }
@@ -135,6 +76,67 @@ internal object AdminJobs {
         }
       }
     }
+
+  private fun CoroutineScope.dispatchRequestCallbacks(
+    config: Vapi4kConfigImpl,
+    callback: RequestResponseCallback,
+  ) {
+    val requestType = callback.request.serverRequestType
+    config.allApplications
+      .filter { it.applicationId == callback.applicationId }
+      .forEach { app ->
+        launchCallbacks(app.applicationAllRequests, app.applicationPerRequests, requestType) {
+          callback.toRequestContext(config)
+        }
+      }
+    launchCallbacks(config.globalAllRequests, config.globalPerRequests, requestType) {
+      callback.toRequestContext(config)
+    }
+  }
+
+  private fun CoroutineScope.dispatchResponseCallbacks(
+    config: Vapi4kConfigImpl,
+    callback: RequestResponseCallback,
+  ) {
+    val hasAppCallbacks = config.allApplications.any { app ->
+      app.applicationAllResponses.isNotEmpty() || app.applicationPerResponses.isNotEmpty()
+    }
+    val hasGlobalCallbacks =
+      config.globalAllResponses.isNotEmpty() || config.globalPerResponses.isNotEmpty()
+
+    if (!hasAppCallbacks && !hasGlobalCallbacks)
+      return
+
+    val resp = runCatching {
+      callback.response.invoke()
+    }.onFailure {
+      logger.error { "Error creating response" }
+      error("Error creating response")
+    }.getOrThrow()
+
+    val requestType = callback.request.serverRequestType
+    config.allApplications.forEach { app ->
+      launchCallbacks(app.applicationAllResponses, app.applicationPerResponses, requestType) {
+        callback.toResponseContext(config, resp)
+      }
+    }
+
+    launchCallbacks(config.globalAllResponses, config.globalPerResponses, requestType) {
+      callback.toResponseContext(config, resp)
+    }
+  }
+
+  private fun <C> CoroutineScope.launchCallbacks(
+    all: List<suspend (C) -> Unit>,
+    per: List<Pair<ServerRequestType, suspend (C) -> Unit>>,
+    requestType: ServerRequestType,
+    context: () -> C,
+  ) {
+    all.forEach { block -> launch { block(context()) } }
+    per
+      .filter { it.first == requestType }
+      .forEach { (_, block) -> launch { block(context()) } }
+  }
 
   suspend fun invokeRequestCallbacks(
     config: Vapi4kConfigImpl,

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/CallbackDispatchTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/CallbackDispatchTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.vapi4k.ServerTest.Companion.configPost
+import com.vapi4k.api.model.GroqModelType
+import com.vapi4k.api.vapi4k.ServerRequestType.ASSISTANT_REQUEST
+import com.vapi4k.api.vapi4k.ServerRequestType.TOOL_CALL
+import com.vapi4k.common.CoreEnvVars.defaultServerPath
+import com.vapi4k.common.Utils.resourceFile
+import com.vapi4k.plugin.Vapi4k
+import com.vapi4k.utils.JsonFilenames.JSON_ASSISTANT_REQUEST
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Exercises the asynchronous callback fan-out performed by `AdminJobs.startCallbackThread`.
+ *
+ * Callbacks are dispatched on a daemon thread that drains `config.callbackChannel`, so each
+ * assertion is wrapped in [eventually] to await the off-thread invocations. The shared counters
+ * are [AtomicInteger]s because they are mutated from that dispatch thread.
+ */
+class CallbackDispatchTest : StringSpec() {
+  init {
+    "global and per-application request callbacks fire for all requests and only matching types" {
+      val globalAll = AtomicInteger()
+      val globalAssistant = AtomicInteger()
+      val globalTool = AtomicInteger()
+      val appAll = AtomicInteger()
+      val appAssistant = AtomicInteger()
+      val appTool = AtomicInteger()
+
+      testApplication {
+        application {
+          install(Vapi4k) {
+            onAllRequests { globalAll.incrementAndGet() }
+            onRequest(ASSISTANT_REQUEST) { globalAssistant.incrementAndGet() }
+            onRequest(TOOL_CALL) { globalTool.incrementAndGet() }
+
+            inboundCallApplication {
+              onAllRequests { appAll.incrementAndGet() }
+              onRequest(ASSISTANT_REQUEST) { appAssistant.incrementAndGet() }
+              onRequest(TOOL_CALL) { appTool.incrementAndGet() }
+              onAssistantRequest {
+                assistant { groqModel { modelType = GroqModelType.LLAMA3_70B_8192 } }
+              }
+            }
+          }
+        }
+
+        val response = client.post("/inboundCall/$defaultServerPath") {
+          configPost()
+          setBody(resourceFile(JSON_ASSISTANT_REQUEST))
+        }
+        response.status shouldBe HttpStatusCode.OK
+
+        eventually(10.seconds) {
+          globalAll.get() shouldBe 1
+          globalAssistant.get() shouldBe 1
+          appAll.get() shouldBe 1
+          appAssistant.get() shouldBe 1
+        }
+      }
+
+      // TOOL_CALL handlers must never fire for an assistant-request message.
+      globalTool.get() shouldBe 0
+      appTool.get() shouldBe 0
+    }
+
+    "global response callbacks fire for all responses and only matching types" {
+      val globalAllResponses = AtomicInteger()
+      val assistantResponse = AtomicInteger()
+      val toolResponse = AtomicInteger()
+
+      testApplication {
+        application {
+          install(Vapi4k) {
+            onAllResponses { globalAllResponses.incrementAndGet() }
+            onResponse(ASSISTANT_REQUEST) { assistantResponse.incrementAndGet() }
+            onResponse(TOOL_CALL) { toolResponse.incrementAndGet() }
+
+            inboundCallApplication {
+              onAssistantRequest {
+                assistant { groqModel { modelType = GroqModelType.LLAMA3_70B_8192 } }
+              }
+            }
+          }
+        }
+
+        val response = client.post("/inboundCall/$defaultServerPath") {
+          configPost()
+          setBody(resourceFile(JSON_ASSISTANT_REQUEST))
+        }
+        response.status shouldBe HttpStatusCode.OK
+
+        eventually(10.seconds) {
+          globalAllResponses.get() shouldBe 1
+          assistantResponse.get() shouldBe 1
+        }
+      }
+
+      toolResponse.get() shouldBe 0
+    }
+
+    "request callbacks are dispatched only to the application that handled the request" {
+      val appA = AtomicInteger()
+      val appB = AtomicInteger()
+
+      testApplication {
+        application {
+          install(Vapi4k) {
+            inboundCallApplication {
+              serverPath = "/appA"
+              onAllRequests { appA.incrementAndGet() }
+              onAssistantRequest {
+                assistant { groqModel { modelType = GroqModelType.LLAMA3_70B_8192 } }
+              }
+            }
+            inboundCallApplication {
+              serverPath = "/appB"
+              onAllRequests { appB.incrementAndGet() }
+              onAssistantRequest {
+                assistant { groqModel { modelType = GroqModelType.LLAMA3_70B_8192 } }
+              }
+            }
+          }
+        }
+
+        val response = client.post("/inboundCall/appA") {
+          configPost()
+          setBody(resourceFile(JSON_ASSISTANT_REQUEST))
+        }
+        response.status shouldBe HttpStatusCode.OK
+
+        eventually(10.seconds) {
+          appA.get() shouldBe 1
+        }
+      }
+
+      // The request targeted appA, so appB's callbacks must not be invoked.
+      appB.get() shouldBe 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`AdminJobs.startCallbackThread()` drained `config.callbackChannel` and fanned each callback out to the registered handlers inside a deeply nested block (`thread → while → runCatching → runBlocking → for → coroutineScope → when → branch → filter/forEach → with → forEach → launch`), which is why it carried an explicit `@Suppress("CyclomaticComplexMethod")`.

This refactor flattens that nesting with **no behavior change**:

- Extracted the `REQUEST` / `RESPONSE` branch bodies into private `CoroutineScope` extensions `dispatchRequestCallbacks` / `dispatchResponseCallbacks`.
- Introduced a single generic `launchCallbacks` helper that handles the repeated "fire every *all* handler + every *per* handler matching the request type" pattern (used by all four call sites).
- Removed the `@Suppress("CyclomaticComplexMethod")` annotation.

The redundant per-application `isNotEmpty()` guard is dropped (an empty list launches nothing); the outer `hasAppCallbacks || hasGlobalCallbacks` guard that gates the response build is preserved, as is the response-creation error path.

## Tests

New `CallbackDispatchTest` exercises the refactored dispatch through the real plugin path (the `callbackChannel` + daemon dispatch thread via Ktor's `testApplication`):

1. Global and per-application request callbacks fire for all requests and only matching types.
2. Global response callbacks fire for all responses and only matching types.
3. Request callbacks are dispatched only to the application that handled the request (`applicationId` filtering).

Async dispatch is awaited with Kotest's `eventually`; counters are `AtomicInteger` since they are mutated from the dispatch thread.

## Verification

- `./gradlew lintKotlin detekt :vapi4k-core:test` — all green (lint and detekt clean with the suppression removed, full core suite passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)