### PR TITLE
Reduce complexity of FunctionDetails.invokeMethod()

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/functions/FunctionDetails.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dsl/functions/FunctionDetails.kt
@@ -39,6 +39,7 @@ import java.lang.reflect.InvocationTargetException
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.plusAssign
 import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.full.callSuspendBy
 import kotlinx.serialization.Serializable
@@ -114,39 +115,44 @@ class FunctionDetails internal constructor(
       else -> error("Unsupported parameter type: $argType")
     }
 
-  @Suppress("CyclomaticComplexMethod")
   private suspend fun invokeMethod(
     requestContext: RequestContextImpl,
     invokeArgs: JsonElement,
   ): String {
     val function = obj.findFunction(functionName)
-    val argNames = invokeArgs.keys
-    logger.info { "Invoking method $fqName with args $argNames" }
+    logger.info { "Invoking method $fqName with args ${invokeArgs.keys}" }
+
+    // Value-parameter map (declared args + auto-injected RequestContext), used for both the
+    // call and the debug log. The instance receiver is added separately below.
+    val argMap = buildArgMap(function, requestContext, invokeArgs)
+    logger.info { "Calling \"${toolCall?.description.orEmpty()}\" tool service: $functionName(${formatArgs(argMap)})" }
+
+    val callMap = function.instanceParameter?.let { argMap + (it to obj) } ?: argMap
+    return invokeFunction(function, callMap)
+  }
+
+  private fun buildArgMap(
+    function: KFunction<*>,
+    requestContext: RequestContextImpl,
+    invokeArgs: JsonElement,
+  ): Map<KParameter, Any> {
     val paramMap = function.valueParameters.toMap()
     val valueMap =
-      argNames
-        .associate { argName ->
-          val param = paramMap[argName] ?: error("Parameter $argName not found in method $fqName")
-          param to getArgValue(invokeArgs, argName, param.type)
-        }
+      invokeArgs.keys.associate { argName ->
+        val param = paramMap[argName] ?: error("Parameter $argName not found in method $fqName")
+        param to getArgValue(invokeArgs, argName, param.type)
+      }
 
-    // Check if the function has a RequestContext parameter
-    val requestContextParam =
-      function.valueParameters.firstOrNull { it.second.isRequestContextClass() }?.second
+    // If the function declares a RequestContext parameter, inject it (it is not in the JSON args).
+    val requestContextParam = function.valueParameters.firstOrNull { it.second.isRequestContextClass() }?.second
+    return requestContextParam?.let { valueMap + (it to requestContext) } ?: valueMap
+  }
 
-    // If the function has a request parameter, add it to the valueMap
-    val valueMapWithRequestContext =
-      requestContextParam?.let { param -> valueMap.toMutableMap().also { it[param] = requestContext } } ?: valueMap
-
-    val callMap =
-      function.instanceParameter?.let { param ->
-        valueMapWithRequestContext.toMutableMap().also { it[param] = obj }
-      } ?: valueMapWithRequestContext
-
-    val funcArgs = if (valueMapWithRequestContext.isEmpty()) {
+  private fun formatArgs(argMap: Map<KParameter, Any>): String =
+    if (argMap.isEmpty()) {
       "with no args"
     } else {
-      valueMapWithRequestContext
+      argMap
         .mapNotNull { (param, value) ->
           when (param.type.asKClass()) {
             RequestContext::class -> "${param.name}: RequestContext Value"
@@ -158,9 +164,11 @@ class FunctionDetails internal constructor(
           }
         }.joinToString(", ")
     }
-    logger.info { "Calling \"${toolCall?.description.orEmpty()}\" tool service: $functionName($funcArgs)" }
 
-    // Invoke the function with the arguments
+  private suspend fun invokeFunction(
+    function: KFunction<*>,
+    callMap: Map<KParameter, Any>,
+  ): String {
     val result =
       if (function.isSuspend)
         function.callSuspendBy(callMap)

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/FunctionDetailsTest.kt
@@ -16,6 +16,9 @@
 
 package com.vapi4k
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.pambrose.common.json.toJsonElement
 import com.vapi4k.api.tools.ToolCall
 import com.vapi4k.api.toolservice.ToolCallService
@@ -32,6 +35,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.delay
+import org.slf4j.LoggerFactory
 
 class FunctionDetailsTest : StringSpec() {
   class StringService {
@@ -107,6 +112,30 @@ class FunctionDetailsTest : StringSpec() {
       requestFailedMessage {
         content = "Failed: $errorMessage"
       }
+    }
+  }
+
+  class SuspendService {
+    @ToolCall("Suspends then greets")
+    suspend fun slowGreet(name: String): String {
+      delay(1)
+      return "Hi, $name!"
+    }
+  }
+
+  // Captures the log lines emitted during [block], keeping only the "...tool service:..." line
+  // produced by FunctionDetails.formatArgs() (its only observable surface).
+  private suspend fun captureToolServiceLogs(block: suspend () -> Unit): List<String> {
+    val rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+    val appender = ListAppender<ILoggingEvent>()
+    appender.start()
+    rootLogger.addAppender(appender)
+    return try {
+      block()
+      appender.list.map { it.formattedMessage }.filter { it.contains("tool service:") }
+    } finally {
+      rootLogger.detachAppender(appender)
+      appender.stop()
     }
   }
 
@@ -346,6 +375,98 @@ class FunctionDetailsTest : StringSpec() {
       )
 
       result shouldBe "false"
+    }
+
+    "invokeToolMethod handles suspend ToolCall functions" {
+      val service = SuspendService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"name":"World"}""".toJsonElement()
+      var result = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = { result = it },
+        errorAction = { result = it },
+      )
+
+      result shouldBe "Hi, World!"
+    }
+
+    "invokeToolMethod calls errorAction when a JSON arg has no matching parameter" {
+      val service = StringService()
+      val details = createFunctionDetails(service)
+      val requestContext = createRequestContext()
+      val args = """{"unknown":"x"}""".toJsonElement()
+      var errorResult = ""
+
+      details.invokeToolMethod(
+        isTool = true,
+        requestContext = requestContext,
+        invokeArgs = args,
+        successAction = {},
+        errorAction = { errorResult = it },
+      )
+
+      errorResult shouldContain "Parameter unknown not found"
+    }
+
+    "logs 'with no args' for a zero-arg tool" {
+      val details = createFunctionDetails(UnitService())
+      val requestContext = createRequestContext()
+
+      val logs =
+        captureToolServiceLogs {
+          details.invokeToolMethod(
+            isTool = true,
+            requestContext = requestContext,
+            invokeArgs = """{}""".toJsonElement(),
+            successAction = {},
+            errorAction = {},
+          )
+        }
+
+      logs.single { it.contains("doNothing(") } shouldContain "doNothing(with no args)"
+    }
+
+    "logs numeric arguments without quotes" {
+      val details = createFunctionDetails(IntService())
+      val requestContext = createRequestContext()
+
+      val logs =
+        captureToolServiceLogs {
+          details.invokeToolMethod(
+            isTool = true,
+            requestContext = requestContext,
+            invokeArgs = """{"a":3,"b":4}""".toJsonElement(),
+            successAction = {},
+            errorAction = {},
+          )
+        }
+
+      logs.single { it.contains("add(") } shouldContain "add(a: 3, b: 4)"
+    }
+
+    "logs string arguments quoted and the injected RequestContext label" {
+      val details = createFunctionDetails(ContextService())
+      val requestContext = createRequestContext()
+
+      val logs =
+        captureToolServiceLogs {
+          details.invokeToolMethod(
+            isTool = true,
+            requestContext = requestContext,
+            invokeArgs = """{"name":"Alice"}""".toJsonElement(),
+            successAction = {},
+            errorAction = {},
+          )
+        }
+
+      val line = logs.single { it.contains("withContext(") }
+      line shouldContain "name: \"Alice\""
+      line shouldContain "requestContext: RequestContext Value"
     }
   }
 }


### PR DESCRIPTION
## Summary

`FunctionDetails.invokeMethod()` carried a `@Suppress("CyclomaticComplexMethod")` because it bundled five concerns in one body. This splits it into a thin orchestrator plus three focused private helpers and drops the suppress:

- **`buildArgMap()`** — builds the JSON-arg → `KParameter` value map and injects the auto-supplied `RequestContext`.
- **`formatArgs()`** — renders the human-readable arg string for the debug log (the 6-branch `when` that was the biggest complexity contributor).
- **`invokeFunction()`** — suspend-vs-sync dispatch (`callSuspendBy`/`callBy`) and the Unit-return → `""` conversion.

Behavior is preserved exactly. The key subtlety: `formatArgs()` keys its empty-check off the value-param map (not the instance-bearing call map), so zero-arg tools still log `"with no args"`; the instance receiver would have fallen into the `else -> null` branch anyway, so non-empty output is identical too.

## Tests

Added coverage for the restructured paths in `FunctionDetailsTest`:

- **suspend `@ToolCall` invocation** — exercises `invokeFunction`'s `callSuspendBy` branch (previously uncovered; all prior test services were non-suspend).
- **"parameter not found" error path** — a JSON key with no matching parameter surfaces through `errorAction`.
- **`formatArgs` log rendering** — captured via a logback `ListAppender`, confirming `"with no args"`, numeric-unquoted, string-quoted, and the injected `RequestContext` label.

## Verification

- `./gradlew :vapi4k-core:test` — full suite green (17/17 in `FunctionDetailsTest`, 12 original + 5 new)
- `./gradlew :vapi4k-core:lintKotlin` — clean
- `./gradlew :vapi4k-core:detekt` — clean (lints both main and test sources); the `@Suppress` is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)