### PR TITLE
Replace ModelSerializer when-dispatch with a class-keyed registry

### DIFF
--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/AnthropicBedrockModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/AnthropicBedrockModelDto.kt
@@ -48,7 +48,7 @@ data class AnthropicBedrockModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.ANTHROPIC_BEDROCK
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/AnthropicModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/AnthropicModelDto.kt
@@ -48,7 +48,7 @@ data class AnthropicModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.ANTHROPIC
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/CerebrasModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/CerebrasModelDto.kt
@@ -48,7 +48,7 @@ data class CerebrasModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.CEREBRAS
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/CommonModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/CommonModelDto.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.reflect.KClass
 
 @Serializable(with = ModelSerializer::class)
 interface CommonModelDto {
@@ -33,90 +34,41 @@ interface CommonModelDto {
   val functions: MutableList<FunctionDto>
   var knowledgeBaseDto: KnowledgeBaseDto?
   val messages: MutableList<RoleMessageDto>
+
+  fun assignEnumOverrides() {} // providers with an enum model type override this
 }
 
 object ModelSerializer : KSerializer<CommonModelDto> {
   override val descriptor: SerialDescriptor = buildClassSerialDescriptor("AbstractModelDto")
 
-  @Suppress("CyclomaticComplexMethod")
+  private val serializers: Map<KClass<out CommonModelDto>, KSerializer<out CommonModelDto>> =
+    mapOf(
+      AnthropicBedrockModelDto::class to AnthropicBedrockModelDto.serializer(),
+      AnthropicModelDto::class to AnthropicModelDto.serializer(),
+      AnyscaleModelDto::class to AnyscaleModelDto.serializer(),
+      CerebrasModelDto::class to CerebrasModelDto.serializer(),
+      CustomLLMModelDto::class to CustomLLMModelDto.serializer(),
+      DeepInfraModelDto::class to DeepInfraModelDto.serializer(),
+      DeepSeekModelDto::class to DeepSeekModelDto.serializer(),
+      GoogleModelDto::class to GoogleModelDto.serializer(),
+      GroqModelDto::class to GroqModelDto.serializer(),
+      InflectionAIModelDto::class to InflectionAIModelDto.serializer(),
+      OpenAIModelDto::class to OpenAIModelDto.serializer(),
+      OpenRouterModelDto::class to OpenRouterModelDto.serializer(),
+      PerplexityAIModelDto::class to PerplexityAIModelDto.serializer(),
+      TogetherAIModelDto::class to TogetherAIModelDto.serializer(),
+      XaiModelDto::class to XaiModelDto.serializer(),
+    )
+
   override fun serialize(
     encoder: Encoder,
     value: CommonModelDto,
   ) {
-    when (value) {
-      is AnthropicBedrockModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(AnthropicBedrockModelDto.serializer(), value)
-      }
-
-      is AnyscaleModelDto -> {
-        encoder.encodeSerializableValue(AnyscaleModelDto.serializer(), value)
-      }
-
-      is AnthropicModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(AnthropicModelDto.serializer(), value)
-      }
-
-      is CerebrasModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(CerebrasModelDto.serializer(), value)
-      }
-
-      is CustomLLMModelDto -> {
-        encoder.encodeSerializableValue(CustomLLMModelDto.serializer(), value)
-      }
-
-      is DeepInfraModelDto -> {
-        encoder.encodeSerializableValue(DeepInfraModelDto.serializer(), value)
-      }
-
-      is DeepSeekModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(DeepSeekModelDto.serializer(), value)
-      }
-
-      is GoogleModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(GoogleModelDto.serializer(), value)
-      }
-
-      is GroqModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(GroqModelDto.serializer(), value)
-      }
-
-      is InflectionAIModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(InflectionAIModelDto.serializer(), value)
-      }
-
-      is OpenAIModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(OpenAIModelDto.serializer(), value)
-      }
-
-      is OpenRouterModelDto -> {
-        encoder.encodeSerializableValue(OpenRouterModelDto.serializer(), value)
-      }
-
-      is PerplexityAIModelDto -> {
-        encoder.encodeSerializableValue(PerplexityAIModelDto.serializer(), value)
-      }
-
-      is TogetherAIModelDto -> {
-        encoder.encodeSerializableValue(TogetherAIModelDto.serializer(), value)
-      }
-
-      is XaiModelDto -> {
-        value.assignEnumOverrides()
-        encoder.encodeSerializableValue(XaiModelDto.serializer(), value)
-      }
-
-      else -> {
-        error("Invalid model provider: ${value::class.simpleName}")
-      }
-    }
+    value.assignEnumOverrides()
+    val serializer = serializers[value::class]
+      ?: error("Invalid model provider: ${value::class.simpleName}")
+    @Suppress("UNCHECKED_CAST")
+    encoder.encodeSerializableValue(serializer as KSerializer<CommonModelDto>, value)
   }
 
   override fun deserialize(decoder: Decoder): CommonModelDto =

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/DeepSeekModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/DeepSeekModelDto.kt
@@ -48,7 +48,7 @@ data class DeepSeekModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.DEEP_SEEK
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/GoogleModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/GoogleModelDto.kt
@@ -48,7 +48,7 @@ data class GoogleModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.GOOGLE
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/GroqModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/GroqModelDto.kt
@@ -48,7 +48,7 @@ data class GroqModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.GROQ
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/InflectionAIModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/InflectionAIModelDto.kt
@@ -48,7 +48,7 @@ data class InflectionAIModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.INFLECTION_AI
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/OpenAIModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/OpenAIModelDto.kt
@@ -54,7 +54,7 @@ data class OpenAIModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.OPEN_AI
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
     fallbackModels.addAll(fallbackModelTypes.map { it.desc } + customFallbackModels)
   }

--- a/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/XaiModelDto.kt
+++ b/vapi4k-core/src/main/kotlin/com/vapi4k/dtos/model/XaiModelDto.kt
@@ -48,7 +48,7 @@ data class XaiModelDto(
   @EncodeDefault
   override val provider: ModelType = ModelType.XAI
 
-  fun assignEnumOverrides() {
+  override fun assignEnumOverrides() {
     model = customModel.ifEmpty { modelType.desc }
   }
 

--- a/vapi4k-core/src/test/kotlin/com/vapi4k/ModelSerializerTest.kt
+++ b/vapi4k-core/src/test/kotlin/com/vapi4k/ModelSerializerTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2024 Matthew Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.vapi4k
+
+import com.pambrose.common.json.stringValue
+import com.pambrose.common.json.toJsonElement
+import com.vapi4k.AssistantTest.Companion.newRequestContext
+import com.vapi4k.api.assistant.Assistant
+import com.vapi4k.api.model.AnthropicBedrockModelType
+import com.vapi4k.api.model.AnthropicModelType
+import com.vapi4k.api.model.CerebrasModelType
+import com.vapi4k.api.model.DeepSeekModelType
+import com.vapi4k.api.model.GoogleModelType
+import com.vapi4k.api.model.GroqModelType
+import com.vapi4k.api.model.InflectionAIModelType
+import com.vapi4k.api.model.OpenAIModelType
+import com.vapi4k.api.model.XaiModelType
+import com.vapi4k.dsl.model.ModelType
+import com.vapi4k.dsl.vapi4k.Vapi4kConfigImpl
+import com.vapi4k.dtos.functions.FunctionDto
+import com.vapi4k.dtos.model.CommonModelDto
+import com.vapi4k.dtos.model.KnowledgeBaseDto
+import com.vapi4k.dtos.model.ModelSerializer
+import com.vapi4k.dtos.model.RoleMessageDto
+import com.vapi4k.dtos.tools.ToolDto
+import com.vapi4k.utils.assistantResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+/**
+ * Exercises every concrete model provider through [ModelSerializer]'s class-keyed registry.
+ *
+ * Each case asserts the serialized `provider` and `model` wire values, which catches a mispaired
+ * registry entry (`X::class to Y.serializer()`) and confirms `assignEnumOverrides()` runs for the
+ * enum-model providers while leaving the raw-model providers' `model` untouched (the no-op default).
+ */
+class ModelSerializerTest : StringSpec() {
+  init {
+    Vapi4kConfigImpl()
+  }
+
+  private class ModelCase(
+    val label: String,
+    val provider: String,
+    val model: String,
+    val block: Assistant.() -> Unit,
+  )
+
+  private val modelCases =
+    listOf(
+      // Enum-model providers (assignEnumOverrides copies modelType.desc -> model)
+      ModelCase("anthropicBedrock", "anthropic-bedrock", "claude-3-opus-20240229") {
+        anthropicBedrockModel { modelType = AnthropicBedrockModelType.CLAUDE_3_OPUS_20240229 }
+      },
+      ModelCase("anthropic", "anthropic", "claude-3-opus-20240229") {
+        anthropicModel { modelType = AnthropicModelType.CLAUDE_3_OPUS_20240229 }
+      },
+      ModelCase("cerebras", "cerebras", "llama3.1-8b") {
+        cerebrasModel { modelType = CerebrasModelType.LLAMA3_1_8B }
+      },
+      ModelCase("deepSeek", "deep-seek", "deepseek-chat") {
+        deepSeekModel { modelType = DeepSeekModelType.DEEPSEEK_CHAT }
+      },
+      ModelCase("google", "google", "gemini-2.5-flash") {
+        googleModel { modelType = GoogleModelType.GEMINI_2_5_FLASH }
+      },
+      ModelCase("groq", "groq", "llama3-70b-8192") {
+        groqModel { modelType = GroqModelType.LLAMA3_70B_8192 }
+      },
+      ModelCase("inflectionAI", "inflection-ai", "inflection_3_pi") {
+        inflectionAIModel { modelType = InflectionAIModelType.INFLECTION_3_PI }
+      },
+      ModelCase("openAI", "openai", "gpt-4o-mini") {
+        openAIModel { modelType = OpenAIModelType.GPT_4O_MINI }
+      },
+      ModelCase("xai", "xai", "grok-2") {
+        xaiModel { modelType = XaiModelType.GROK_2 }
+      },
+      // Raw-model providers (no enum; the no-op assignEnumOverrides must leave model untouched)
+      ModelCase("anyscale", "anyscale", "meta-llama/Llama-2-70b-chat-hf") {
+        anyscaleModel { model = "meta-llama/Llama-2-70b-chat-hf" }
+      },
+      ModelCase("customLLM", "custom-llm", "my-custom-model") {
+        customLLMModel {
+          model = "my-custom-model"
+          url = "https://my-llm.example.com/v1"
+        }
+      },
+      ModelCase("deepInfra", "deepinfra", "meta-llama/Llama-2-70b-chat-hf") {
+        deepInfraModel { model = "meta-llama/Llama-2-70b-chat-hf" }
+      },
+      ModelCase("openRouter", "openrouter", "openai/gpt-4") {
+        openRouterModel { model = "openai/gpt-4" }
+      },
+      ModelCase("perplexityAI", "perplexity-ai", "sonar-pro") {
+        perplexityAIModel { model = "sonar-pro" }
+      },
+      ModelCase("togetherAI", "together-ai", "meta-llama/Llama-2-70b-chat-hf") {
+        togetherAIModel { model = "meta-llama/Llama-2-70b-chat-hf" }
+      },
+    )
+
+  init {
+    modelCases.forEach { case ->
+      "${case.label} model routes to its serializer and emits provider + model" {
+        val je =
+          assistantResponse(newRequestContext()) {
+            assistant(case.block)
+          }.toJsonElement()
+        je.stringValue("messageResponse.assistant.model.provider") shouldBe case.provider
+        je.stringValue("messageResponse.assistant.model.model") shouldBe case.model
+      }
+    }
+
+    "registry covers every model provider exactly once" {
+      modelCases.size shouldBe 15
+      modelCases.map { it.provider }.toSet().size shouldBe 15
+    }
+
+    "unregistered CommonModelDto throws Invalid model provider" {
+      shouldThrow<IllegalStateException> {
+        Json.encodeToString(ModelSerializer, FakeModelDto())
+      }.message shouldBe "Invalid model provider: FakeModelDto"
+    }
+  }
+
+  private class FakeModelDto : CommonModelDto {
+    override val provider = ModelType.OPEN_AI
+    override val tools = mutableListOf<ToolDto>()
+    override val functions = mutableListOf<FunctionDto>()
+    override var knowledgeBaseDto: KnowledgeBaseDto? = null
+    override val messages = mutableListOf<RoleMessageDto>()
+  }
+}


### PR DESCRIPTION
## Summary

`ModelSerializer.serialize()` was a 15-branch `when (value)` over every concrete model DTO. The branch count tripped detekt's `CyclomaticComplexMethod` (hence the `@Suppress`), and `assignEnumOverrides()` was applied inconsistently across branches.

This replaces the hand-written `when` with a data-driven dispatch:

- **`CommonModelDto.kt`** — `serialize()` now looks up a `KClass`-keyed serializer registry (built once) and dispatches in ~3 lines; the `@Suppress("CyclomaticComplexMethod")` is gone.
- **`assignEnumOverrides()`** is promoted to a default no-op on the `CommonModelDto` interface, so it's called uniformly instead of per-branch. The 9 enum-model DTOs gain the `override` keyword; the 6 raw-model DTOs inherit the no-op (their `model` string is set directly, so there's nothing to assign — behavior preserved).
- The `as KSerializer<CommonModelDto>` cast is required (KSerializer is contravariant) and runtime-safe: the map keys on `value::class` and pairs each class with its own serializer.

## Tests

New `ModelSerializerTest` (18 tests):
- All **15 providers** driven through the DSL, asserting wire `provider` + `model` — catches a mispaired registry entry and exercises both the enum-override and no-op paths.
- A registry-coverage check (15 distinct providers).
- The new registry-miss `error("Invalid model provider: …")` branch.

## Verification

- `./gradlew :vapi4k-core:compileKotlin detekt lintKotlin` — clean (no remaining complexity suppression).
- `./gradlew :vapi4k-core:test` — full module suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)